### PR TITLE
Wrap transformation in try/except block

### DIFF
--- a/plugin/FERC/render.py
+++ b/plugin/FERC/render.py
@@ -2660,8 +2660,15 @@ def format_numcommadot(model_fact, sign, scale, *args, **kwargs):
     else:
         return '{:,}'.format(val), '0' 
 
+
 def format_dateslahus(model_fact, *args, **kwargs):
-    return model_fact.xValue.strftime('%m/%d/%Y')
+    try:
+        return model_fact.xValue.strftime('%m/%d/%Y')
+    except AttributeError:
+        raise FERCRenderException(
+            "Invalid date '{}'. Can not convert value to month/day/year format".format(model_fact.xValue)
+        )
+
 
 def format_durwordsen(model_fact, *args, **kwargs):
     pattern = r'P((?P<year>\d+)Y)?((?P<month>\d+)M)?((?P<week>\d+)W)?((?P<day>\d+)D)?(T((?P<hour>\d+)H)?((?P<minute>\d+)M)?((?P<second>\d+(\.\d+)?)S)?)?'


### PR DESCRIPTION
#### Description
If an invalid date with a `{http://www.xbrl.org/inlineXBRL/transformation/2010-04-20}dateslashus` transformation is run through the Renderer, it produces the following error:

```
File "/usr/local/lib/python3.9/site-packages/ferc_renderer/render.py", line 881, in substitute_rule
    fact_number)
  File "/usr/local/lib/python3.9/site-packages/ferc_renderer/render.py", line 2445, in format_fact
    scale)
  File "/usr/local/lib/python3.9/site-packages/ferc_renderer/render.py", line 2671, in format_dateslahus
    return model_fact.xValue.strftime('%m/%d/%Y')
AttributeError: 'str' object has no attribute 'strftime'
```

This error only appears to be affecting FERC v1.5 at the moment. But to be on the safe side we should go ahead and guard this transformation like some of the other transformations. By raising a FERCRenderException it allows this [except](https://github.com/xbrlus/xule/blob/main/plugin/FERC/render.py#L2539-L2544) to render the supplied value, but adds a log in the log.txt that is included in renderer zip.

@davidtauriello 
