### PR TITLE
Stop recreating fact index if it already exists

### DIFF
--- a/plugin/xule/XuleProcessor.py
+++ b/plugin/xule/XuleProcessor.py
@@ -268,7 +268,7 @@ def index_model(xule_context):
     fact_index = collections.defaultdict(lambda: collections.defaultdict(set))
 
     facts_to_index = collections.defaultdict(list)
-    if xule_context.model is not None:
+    if xule_context.model is not None and not xule_context.fact_index:
         for model_fact in xule_context.model.factsInInstance:
             if not fact_is_complete(model_fact):
                 # Fact is incomplete. This can be caused by a filing that is still in the process of being built.


### PR DESCRIPTION
#### Description
Xule creates a fact index for each rule set and the ferc renderer has a rule set for each template, so it's recreating an identical index for each template. Removing this redundancy improves performance by 30-40%.

Xule does [add to the index](https://github.com/xbrlus/xule/blob/main/plugin/xule/XuleProcessor.py#L2402-L2405) at one point during rule evaluation to copy information for aspects not included within the instance (and so not discovered during the initial indexing stage).

@davidtauriello 