### PR TITLE
Maximum rule iteration count

### DIFF
--- a/plugin/xule/XuleContext.py
+++ b/plugin/xule/XuleContext.py
@@ -215,6 +215,7 @@ class XuleGlobalContext(object):
         self.precalc_constants = False
         self.expression_trace = dict()
         self.other_taxonomies = dict()
+        self.maximum_iterations = max(getattr(self.options, "xule_max_rule_iterations", 10000), len(model_xbrl.factsInInstance))
         
         # Set up various queues
         self.message_queue = XuleMessageQueue(self.model, getattr(self.options, "xule_multi", False), getattr(self.options, "xule_async", False), cid=id(self.cntlr))

--- a/plugin/xule/XuleProcessor.py
+++ b/plugin/xule/XuleProcessor.py
@@ -202,7 +202,7 @@ def evaluate_rule_set(global_context):
                 if getattr(global_context.options, "xule_crash", False):
                     raise
                 else:
-                    xule_context.global_context.message_queue.error("xule:error", str(e))
+                    xule_context.global_context.message_queue.error("xule:error", "rule %s: %s" % (rule_name, str(e)))
 
             except XuleIterationStop:
                 pass
@@ -523,6 +523,9 @@ def evaluate(rule_part, xule_context, trace_dependent=False, override_table_id=N
     
     This evaluator also includes capturing information about the evaluation for debugging purposes.
     """
+    if xule_context.iter_count > xule_context.global_context.maximum_iterations:
+        raise XuleProcessingError('Rule has run too many iterations')
+
     try:
         # Setup trace information.
         if getattr(xule_context.global_context.options, "xule_trace", False) or getattr(

--- a/plugin/xule/__init__.py
+++ b/plugin/xule/__init__.py
@@ -449,6 +449,14 @@ def xuleCmdOptions(parser):
                       action="store_true",
                       dest="xule_run",
                       help=_("Indicates that the rules should be processed."))
+
+    parserGroup.add_option(
+        "--xule-max-rule-iterations",
+        action="store",
+        dest="xule_max_rule_iterations",
+        default=10000,
+        help=_("The maximum amount of iterations any xule rule should be allowed to run.")
+    )
     
     parserGroup.add_option("--xule-arg",
                           action="append",


### PR DESCRIPTION
#### Description: 
There are cases where duplicate facts can cause certain XULE validations to run through a large number of iterations checking every single permutation of the validation. For example section 402 in FERC has a rule that checks a calculation with 14 concepts. If a document happens to have inconsistent duplicate facts in that section, it can cause that rule to explode with memory and time as it churns through every possible permutation of the duplicate facts. In our test file it runs 250,000 iterations which takes 40+ minutes and 40+ GB of memory. 

This improvement caps the number of iterations a rule can run to 10,000. If a document has more that 10,000 facts, the threshold becomes the number of facts in the document. This greatly improves speed and memory consumption during validation for documents that are still in working progress.

@davidtauriello 