### PR TITLE
get role-description and arcrole-description from object's parent model

### DIFF
--- a/plugin/xule/XuleProperties.py
+++ b/plugin/xule/XuleProperties.py
@@ -329,6 +329,7 @@ def property_networks(xule_context, object_value, *args):
 def property_role(xule_context, object_value, *args):
     if object_value.type == 'network':
         role_uri = object_value.value[NETWORK_INFO][NETWORK_ROLE]
+        role_parent_model = object_value.value[NETWORK_RELATIONSHIP_SET].modelXbrl
         #return xv.XuleValue(xule_context, object_value.value[NETWORK_INFO][NETWORK_ROLE], 'uri')
     elif object_value.type == 'relationship':
         role_uri = object_value.value.linkrole
@@ -336,7 +337,7 @@ def property_role(xule_context, object_value, *args):
         role_uri = object_value.value.role
         #return xv.XuleValue(xule_context, object_value.value.role, 'uri')
 
-    model_role = XuleUtility.role_uri_to_model_role(xule_context.model, role_uri)
+    model_role = XuleUtility.role_uri_to_model_role(role_parent_model, role_uri)
     return xv.XuleValue(xule_context, model_role, 'role')
 
 def property_role_uri(xule_context, object_value, *args):
@@ -354,6 +355,7 @@ def property_role_uri(xule_context, object_value, *args):
 def property_role_description(xule_context, object_value, *args):
     if object_value.type == 'network':
         role_uri = object_value.value[NETWORK_INFO][NETWORK_ROLE]
+        role_parent_model = object_value.value[NETWORK_RELATIONSHIP_SET].modelXbrl
         #return xv.XuleValue(xule_context, object_value.value[NETWORK_INFO][NETWORK_ROLE], 'uri')
     elif object_value.type == 'relationship':
         role_uri = object_value.value.linkrole        
@@ -361,17 +363,18 @@ def property_role_description(xule_context, object_value, *args):
         role_uri = object_value.value.role
         #return xv.XuleValue(xule_context, object_value.value.role, 'uri')
 
-    model_role = XuleUtility.role_uri_to_model_role(xule_context.model, role_uri)
+    model_role = XuleUtility.role_uri_to_model_role(role_parent_model, role_uri)
 
     return xv.XuleValue(xule_context, model_role.definition, 'string')
     
 def property_arcrole(xule_context, object_value, *args):
     if object_value.type == 'network':
         arcrole_uri = object_value.value[NETWORK_INFO][NETWORK_ARCROLE]
+        arcrole_parent_model = object_value.value[NETWORK_RELATIONSHIP_SET].modelXbrl
     else: # relationship
         arcrole_uri = object_value.value.arcrole
 
-    model_arcrole = XuleUtility.arcrole_uri_to_model_role(xule_context.model, arcrole_uri)
+    model_arcrole = XuleUtility.arcrole_uri_to_model_role(arcrole_parent_model, arcrole_uri)
     return xv.XuleValue(xule_context, model_arcrole, 'role')
 
 def property_arcrole_uri(xule_context, object_value, *args):
@@ -384,10 +387,11 @@ def property_arcrole_uri(xule_context, object_value, *args):
 def property_arcrole_description(xule_context, object_value, *args):
     if object_value.type == 'network':
         arcrole_uri = object_value.value[NETWORK_INFO][NETWORK_ARCROLE]
+        arcrole_parent_model = object_value.value[NETWORK_RELATIONSHIP_SET].modelXbrl
     else: # relationship
         arcrole_uri = object_value.value.arcrole
 
-    model_arcrole = XuleUtility.arcrole_uri_to_model_role(xule_context.model, arcrole_uri)
+    model_arcrole = XuleUtility.arcrole_uri_to_model_role(arcrole_parent_model, arcrole_uri)
     return xv.XuleValue(xule_context, model_arcrole.definition, 'string')
 
 def property_concept(xule_context, object_value, *args):


### PR DESCRIPTION
This pr tries to resolve #8 

## Issue
Attributes `.role-description` and `.description` not returning the correct value for roles of a taxonomy loaded as a second taxonomy using `taxonomy(...)`  in the rule (after an initial taxonomy was loaded), indicating that the values for these attritbutes are being retrieved from the initial taxonomy loaded only, resulting in incorrect value or incorect none value.

## Reason for the issue
In XuleProperties.py, functions `property_role`, `property_role_uri`, `property_arcrole`, passes `xule_context.model`  to `role_uri_to_model_role` and `arcrole_uri_to_model_role`. The `xule_context.model` does not seem to be updated to reflect the modelXbrl in the current scope, the functions always pass the initially loaded modelXbrl, which is fine until a new taxonomy is loaded via `taxonomy(...)` then the model passed must be the correct model for the current scope. 

## Suggested Changes
Get the correct modelXbrl from the model object itself before passing it to the conversion functions. This relys on Arelle Cntlr keeping track of which object relates to which parent model, which is very reliable in my experience. 

__You may want to keep track of the model in scope another way, this is why this is a draft pr just to pinpoint the issue.__

## Testing
Same as in issue #8, check for a role that exists only in ESEF 2021 loaded using `taxonomy(...)` after initially loading ESEF 2019.
### Steps to test
**Before applying the changes in this pr**
Save following rule to file test.xule:
```java
constant $other_taxonomy_networks = taxonomy('http://www.esma.europa.eu/taxonomy/2021-03-24/esef_all.xsd')
                                        .networks(none, "http://www.esma.europa.eu/xbrl/role/all/ifrs_17_role-836600o")

output get-from-network-level
for ($nw in $other_taxonomy_networks)
        dict(
        list("Role", $nw.role),
        list("Role description Network attr", $nw.role-description),
        list("Role description (Role attr)", $nw.role.description)
        ) /* Just to print it out in a readable format*/

output get-from-networks-level
list("\nRole description (Networks attr): {string($other_taxonomy_networks.role-description.to-set())}\n---------------\n")[1]
```
Run using the following command (loads ESEF 2019)
```bash
$ arelleCmdLine --plugins xule -f http://www.esma.europa.eu/taxonomy/2019-03-27/esef_all.xsd --internetRecheck never --xule-run --xule-compile test.xule --xule-rule-set test.xule.zip --logFormat "%(message)s"
```
The role description is not detected, the ouput should be as follows:
```bash
{'Role': <xule.XuleValue.XuleRole object at 0x7f38aa9790a0>,
 'Role description (Role attr)': None,
 'Role description Network attr': None}
{'Role': <xule.XuleValue.XuleRole object at 0x7f38aa979790>,
 'Role description (Role attr)': None,
 'Role description Network attr': None}
{'Role': <xule.XuleValue.XuleRole object at 0x7f38aa979d30>,
 'Role description (Role attr)': None,
 'Role description Network attr': None}
{'Role': <xule.XuleValue.XuleRole object at 0x7f38aa988310>,
 'Role description (Role attr)': None,
 'Role description Network attr': None}

Role description (Networks attr): set(None)
```
**After applying the changes in this pr**
Run the same exact test above, the role description is detected and the output should be as follows:
```bash
{'Role': modelRoleType[126944, uri: http://www.esma.europa.eu/xbrl/role/all/ifrs_17_role-836600o, definition: [836600o] Notes - Insurance contracts (IFRS 17), esef_all.xsd line 804]),
 'Role description (Role attr)': '[836600o] Notes - Insurance contracts (IFRS '
                                 '17)',
 'Role description Network attr': '[836600o] Notes - Insurance contracts (IFRS '
                                  '17)'}
{'Role': modelRoleType[126944, uri: http://www.esma.europa.eu/xbrl/role/all/ifrs_17_role-836600o, definition: [836600o] Notes - Insurance contracts (IFRS 17), esef_all.xsd line 804]),
 'Role description (Role attr)': '[836600o] Notes - Insurance contracts (IFRS '
                                 '17)',
 'Role description Network attr': '[836600o] Notes - Insurance contracts (IFRS '
                                  '17)'}
{'Role': modelRoleType[126944, uri: http://www.esma.europa.eu/xbrl/role/all/ifrs_17_role-836600o, definition: [836600o] Notes - Insurance contracts (IFRS 17), esef_all.xsd line 804]),
 'Role description (Role attr)': '[836600o] Notes - Insurance contracts (IFRS '
                                 '17)',
 'Role description Network attr': '[836600o] Notes - Insurance contracts (IFRS '
                                  '17)'}
{'Role': modelRoleType[126944, uri: http://www.esma.europa.eu/xbrl/role/all/ifrs_17_role-836600o, definition: [836600o] Notes - Insurance contracts (IFRS 17), esef_all.xsd line 804]),
 'Role description (Role attr)': '[836600o] Notes - Insurance contracts (IFRS '
                                 '17)',
 'Role description Network attr': '[836600o] Notes - Insurance contracts (IFRS '
                                  '17)'}

Role description (Networks attr): set([836600o] Notes - Insurance contracts (IFRS 17))
---------------
```