### PR TITLE
Validate report period against month_day so that we do not get a key error in get_dates()

### DIFF
--- a/plugin/FERC/render.py
+++ b/plugin/FERC/render.py
@@ -1368,18 +1368,19 @@ def get_dates(modelXbrl):
             report_year = year_match[1] if year_match is not None else None
             report_period = period_match[1].upper() if period_match is not None else None
 
-    if not report_year or not report_period:
-        raise FERCRenderException(
-            'Cannot obtain a valid report year({year}) or report period({period}) from the XBRL document'.format(
-                year=report_year, period=report_period
-            )
-        )
     month_day = {
         'Q4': ('01-01', '12-31'),
         'Q3': ('01-01', '09-30'),
         'Q2': ('01-01', '06-30'),
         'Q1': ('01-01', '03-31')
     }
+
+    if not report_year or report_period not in month_day:
+        raise FERCRenderException(
+            'Cannot obtain a valid report year({year}) or report period({period}) from the XBRL document'.format(
+                year=report_year, period=report_period
+            )
+        )
 
     return (
         ('current-start={}-{}'.format(report_year, '01-01')),


### PR DESCRIPTION
#### Description:
When a value for report_period does not conform to the `Q1`, `Q2`, `Q3` or `Q4`, then a key error can be thrown in the return of `get_dates()`. This PR rearranges report_year and report_period so that report_period can verify that the value is in the above list of values.

#### Testing:
Create a document that has a report_period set as something random like `Quarter 1`. Run it against master and notice that you get a key error. Run the same doc against this branch and you will get a nicely formatted FERCRenderException that explains what the actual issue is.

@campbellpryde
@davidtauriello