### PR TITLE
Handle the case were model type is a list

### DIFF
--- a/plugin/xule/XuleContext.py
+++ b/plugin/xule/XuleContext.py
@@ -32,6 +32,7 @@ from arelle import FileSource
 from arelle import ModelManager
 from queue import Queue
 from multiprocessing import Queue as M_Queue, Manager, cpu_count
+from collections import defaultdict
 import datetime
 from time import sleep
 import copy
@@ -216,6 +217,7 @@ class XuleGlobalContext(object):
         self.expression_trace = dict()
         self.other_taxonomies = dict()
         self.maximum_iterations = max(getattr(self.options, "xule_max_rule_iterations", 10000), len(model_xbrl.factsInInstance) + 10 )
+        self.ancestry_cache = defaultdict(dict)
         
         # Set up various queues
         self.message_queue = XuleMessageQueue(self.model, getattr(self.options, "xule_multi", False), getattr(self.options, "xule_async", False), cid=id(self.cntlr))

--- a/plugin/xule/XuleValue.py
+++ b/plugin/xule/XuleValue.py
@@ -41,6 +41,13 @@ import pprint
 import re
 import textwrap
 
+from enum import Enum
+
+
+class SpecialItemTypes(Enum):
+    ENUM_ITEM_TYPE = '{http://xbrl.org/2020/extensible-enumerations-2.0}enumerationItemType'
+    ENUM_SET_ITEM_TYPE = '{http://xbrl.org/2020/extensible-enumerations-2.0}enumerationSetItemType'
+
 
 class XuleValueSet:
     def __init__(self, values=None):
@@ -94,7 +101,6 @@ class XuleValue:
         self.tag = tag if tag is not None else self
         
         if self.type in ('list', 'set') and self.shadow_collection is None:
-        #if self.type in ('list', 'set'):            
             shadow = [x.shadow_collection if x.type in ('set', 'list', 'dictionary') else x.value for x in self.value]
             if self.type == 'list':
                 self.shadow_collection = tuple(shadow)
@@ -190,7 +196,7 @@ class XuleValue:
         #set value, type, fact on the XuleValue
         if orig_type == 'fact':
             #get the underlying value and determine the type
-            if "{http://xbrl.org/2020/extensible-enumerations-2.0}enumerationSetItemType" in self._type_ancestry(orig_value.concept.type):
+            if self._special_type_in_ancestry(xule_context, SpecialItemTypes.ENUM_SET_ITEM_TYPE, orig_value.concept.type):
                 # This is concept that is an extensibile enumeration set. Arelle will pass the valueas
                 # a list of QNames. Need to convert to a set of XuleValues where each Xulevalue is a
                 # "qname" xule type.
@@ -202,7 +208,7 @@ class XuleValue:
                     enum_value_type, enum_compute_value = model_to_xule_type(xule_context, enum)
                     enum_set.add(XuleValue(xule_context, enum_compute_value, enum_value_type))
                 return 'set', enum_set, orig_value
-            elif "{http://xbrl.org/2020/extensible-enumerations-2.0}enumerationItemType" in self._type_ancestry(orig_value.concept.type):
+            elif self._special_type_in_ancestry(xule_context, SpecialItemTypes.ENUM_ITEM_TYPE, orig_value.concept.type):
                 # This should be a single qname, but Arelle puts it in a list
                 if isinstance(orig_value.xValue, list):
                     if len(orig_value.xValue) == 1:
@@ -218,11 +224,22 @@ class XuleValue:
         else:
             return orig_type, orig_value, None
 
-    def _type_ancestry(self, model_type):
-        if model_type.typeDerivedFrom is None:
-            return [model_type.qname.clarkNotation]
+    def _special_type_in_ancestry(self, xule_context, find, model_type):
+        cached_value = xule_context.global_context.ancestry_cache.get(model_type, {}).get(find)
+        if cached_value is not None:
+            return cached_value
+        elif model_type.qname.clarkNotation == find.value:
+            xule_context.global_context.ancestry_cache[model_type][find] = True
+            return True
+        derived = model_type.typeDerivedFrom
+        if isinstance(derived, list):
+            is_derived_from = any(
+                self._special_type_in_ancestry(xule_context, find, t) for t in model_type.typeDerivedFrom if t is not None
+            )
         else:
-            return [model_type.qname.clarkNotation] + self._type_ancestry(model_type.typeDerivedFrom)
+            is_derived_from = derived is not None and self._special_type_in_ancestry(xule_context, find, derived)
+        xule_context.global_context.ancestry_cache[model_type][find] = is_derived_from
+        return is_derived_from
 
     @property
     def is_fact(self):


### PR DESCRIPTION
#### Description: 
`xbrli:dateTimeItemType` derives from `DateUnion`, which has 2 parents(`date` and `dateTime`). When the hierarchy code tries to establish this hierarchy it blows up because it is not expecting a list as the derived from type. This causes  a 'list' object has no attribute 'typeDerivedFrom` python error. 

This PR updates `_type_ancestry()` to cache ancestry to improve performance as well as handling multiple parent derivation.

#### Testing:
Run [list_no_typeDerivedFrom.zip](https://github.com/xbrlus/xule/files/9354907/list_no_typeDerivedFrom.zip) and verify that the 'list' object has no attribute 'typeDerivedFrom` no longer gets thrown in the validation results.

@campbellpryde 
@davidtauriello 