### PR TITLE
Make XULE compiler grammar compatible with pyparsing 3

### DIFF
--- a/plugin/xule/XuleParser.py
+++ b/plugin/xule/XuleParser.py
@@ -77,7 +77,7 @@ def parseFile(dir, fileName, xuleGrammar, ruleSet):
 
             returns = []
             def threaded_parse():
-                returns.append(xuleGrammar.parseFile(full_file_name).asDict())
+                returns.append(xuleGrammar.parse_file(full_file_name).as_dict())
 
             t = threading.Thread(target=threaded_parse)
             t.start()
@@ -90,7 +90,7 @@ def parseFile(dir, fileName, xuleGrammar, ruleSet):
             fixForPyParsing(parseRes)
 
 
-            #parseRes = xuleGrammar.parseFile(full_file_name).asDict()
+            #parseRes = xuleGrammar.parse_file(full_file_name).as_dict()
             end_time = datetime.datetime.today()
             print("%s: parse end. Took %s" % (datetime.datetime.isoformat(end_time), end_time - start_time))
             ast_start = datetime.datetime.today()

--- a/plugin/xule/XuleParser.py
+++ b/plugin/xule/XuleParser.py
@@ -22,7 +22,7 @@ limitations under the License.
 $Change: 23280 $
 DOCSKIP
 """
-from pyparsing import ParseResults, lineno, ParseException, ParseSyntaxException, ParserElement
+from pyparsing import ParseResults, lineno, ParseException, ParseSyntaxException
 from . import XuleRuleSet as xrs
 from . import XuleRuleSetBuilder as xrsb
 from .xule_grammar import get_grammar

--- a/plugin/xule/xule_grammar.py
+++ b/plugin/xule/xule_grammar.py
@@ -440,7 +440,7 @@ def get_grammar():
                 nodeName('functionReference')) 
 
     #if expression
-    elseIfExpr = (ZeroOrMore(Group(Suppress(elseOp + ifOp) + 
+    elseIfExpr = (OneOrMore(Group(Suppress(elseOp + ifOp) + 
                                     blockExpr.setResultsName("condition") +
                                     blockExpr.setResultsName("thenExpr") +
                                     nodeName('elseIf')
@@ -454,7 +454,7 @@ def get_grammar():
                    
                    blockExpr.setResultsName("thenExpr") +
                    # this will flatten nested if conditions 
-                   elseIfExpr +
+                   Optional(elseIfExpr) +
                    Suppress(elseOp) + 
                    blockExpr.setResultsName("elseExpr") +
                    nodeName('ifExpr')

--- a/plugin/xule/xule_grammar.py
+++ b/plugin/xule/xule_grammar.py
@@ -213,7 +213,7 @@ def get_grammar():
     stringExpr = Suppress(Literal('{')) + blockExpr + Suppress(Literal('}'))
     singleQuoteString = Suppress(Literal("'")) + ZeroOrMore(stringEscape | stringExpr | Group(Combine(OneOrMore(Regex("[^\\\\'{]"))).setResultsName('value') + nodeName('baseString'))) + Suppress(Literal("'"))
     doubleQuoteString = Suppress(Literal('"')) + ZeroOrMore(stringEscape | stringExpr | Group(Combine(OneOrMore(Regex('[^\\\\"{]'))).setResultsName('value') + nodeName('baseString'))) + Suppress(Literal('"'))
-    stringLiteral = Group((Group(singleQuoteString | doubleQuoteString).setResultsName('stringList') + nodeName('string'))).leaveWhitespace()
+    stringLiteral = Group((Suppress(Optional(White())) + Group(singleQuoteString | doubleQuoteString).setResultsName('stringList') + Suppress(Optional(White())) + nodeName('string'))).leaveWhitespace()
 
     #boolean literals
     booleanLiteral = Group((CaselessKeyword("true") | CaselessKeyword("false")).setResultsName("value") + nodeName('boolean'))

--- a/plugin/xule/xule_grammar.py
+++ b/plugin/xule/xule_grammar.py
@@ -22,12 +22,12 @@ limitations under the License.
 $Change: 23443 $
 DOCSKIP
 """
-from pyparsing import (Word, Keyword,  CaselessKeyword, ParseResults, infixNotation,
+from pyparsing import (Word, CaselessKeyword,
                  Literal, CaselessLiteral, FollowedBy, opAssoc,
                  Combine, Optional, nums, Forward, Group, ZeroOrMore,  
                  ParserElement,  delimitedList, Suppress, Regex, 
-                 QuotedString, OneOrMore, oneOf, cStyleComment, CharsNotIn,
-                 lineEnd, White, SkipTo, Empty, stringStart, stringEnd, alphas, printables, removeQuotes)
+                 OneOrMore, oneOf, cStyleComment, CharsNotIn,
+                 lineEnd, White, SkipTo, Empty, stringStart, stringEnd, printables)
 
 INRESULT = False
 

--- a/plugin/xule/xule_grammar.py
+++ b/plugin/xule/xule_grammar.py
@@ -40,7 +40,7 @@ def out_result(*args):
     INRESULT = False
 
 def buildPrecedenceExpressions( baseExpr, opList, lpar=Suppress('('), rpar=Suppress(')')):
-    """Simplified and modified version of pyparsing infixNotation helper function
+    """Simplified and modified version of pyparsing infix_notation helper function
     
     Args:
         baseExpr: The parser that is the operand of the operations
@@ -58,7 +58,7 @@ def buildPrecedenceExpressions( baseExpr, opList, lpar=Suppress('('), rpar=Suppr
         This returns a pyparsing parser.
     
     This version only handles binary and unary operations that are left associative. It also does not handle parenthesized
-    expressions. It uses the same parameters as the infixNotation. This makes it easy to switch between this 
+    expressions. It uses the same parameters as the infix_notation. This makes it easy to switch between this 
     version and the official pyparsing version.
     
     This version add results names to the parser. When outputting as a dictionary, it will generate a structure as:
@@ -80,16 +80,16 @@ def buildPrecedenceExpressions( baseExpr, opList, lpar=Suppress('('), rpar=Suppr
         
         #check restrictions
         if arity not in (1, 2):
-            raise ValueError('This is a modified version of the pyparsing infixNotation helper function. Only arity of 1 or 2 is supported.')
+            raise ValueError('This is a modified version of the pyparsing infix_notation helper function. Only arity of 1 or 2 is supported.')
         if arity == 1 and rightLeftAssoc != OpAssoc.RIGHT:
-            raise ValueError('This is a modified version of the pyparsing infixNotation helper function. When arity is 1 only right associative operations are supported.')
+            raise ValueError('This is a modified version of the pyparsing infix_notation helper function. When arity is 1 only right associative operations are supported.')
         if arity == 2 and rightLeftAssoc != OpAssoc.LEFT:
-            raise ValueError('This is a modified version of the pyparsing infixNotation helper function. When arity is 2 only left associative operations are supported.')
+            raise ValueError('This is a modified version of the pyparsing infix_notation helper function. When arity is 2 only left associative operations are supported.')
 
         if opExpr is None:
-            raise ValueError('This is a modified version of the pyparsing infixNotation helper function. opExpr must be supplied.')
+            raise ValueError('This is a modified version of the pyparsing infix_notation helper function. opExpr must be supplied.')
         termName = "%s term" % opExpr if arity < 3 else "%s%s term" % opExpr
-        thisExpr = Forward().setName(termName)
+        thisExpr = Forward().set_name(termName)
         
         if arity == 1:
 #             # try to avoid LR with this extra test
@@ -99,8 +99,8 @@ def buildPrecedenceExpressions( baseExpr, opList, lpar=Suppress('('), rpar=Suppr
             if exprName is None:
                 exprName = 'unaryExpr'
             matchExpr = (FollowedBy(opExpr + lastExpr) + \
-                        ( (opExpr.setResultsName('op') + ~Word(nums)).leaveWhitespace() + lastExpr.setResultsName('expr') ) + nodeName(exprName))
-                        #Group(OneOrMore(Group(opExpr.setResultsName('op') + nodeName('opExpr')))).setResultsName('ops') + lastExpr.setResultsName('expr') + nodeName(exprName) )
+                        ( (opExpr.set_results_name('op') + ~Word(nums)).leave_whitespace() + lastExpr.set_results_name('expr') ) + nodeName(exprName))
+                        #Group(OneOrMore(Group(opExpr.set_results_name('op') + nodeName('opExpr')))).set_results_name('ops') + lastExpr.set_results_name('expr') + nodeName(exprName) )
 
                             
         else: #arity == 2
@@ -108,31 +108,31 @@ def buildPrecedenceExpressions( baseExpr, opList, lpar=Suppress('('), rpar=Suppr
             if exprName is None:
                 exprName = 'binaryExpr'
             matchExpr = (FollowedBy(lastExpr + opExpr + lastExpr) + \
-                      ( lastExpr.setResultsName('leftExpr') + 
-                        Group(OneOrMore(Group( opExpr.setResultsName('op') + 
-                                   lastExpr.setResultsName('rightExpr') +
-                                   nodeName('rightOperation')))).setResultsName('rights') ) +
+                      ( lastExpr.set_results_name('leftExpr') + 
+                        Group(OneOrMore(Group( opExpr.set_results_name('op') + 
+                                   lastExpr.set_results_name('rightExpr') +
+                                   nodeName('rightOperation')))).set_results_name('rights') ) +
                               nodeName(exprName)
                          )
             
         if pa:
             if isinstance(pa, (tuple, list)):
-                matchExpr.setParseAction(*pa)
+                matchExpr.set_parse_action(*pa)
             else:
-                matchExpr.setParseAction(pa)
-        thisExpr <<= (Group(matchExpr.setName(termName)) | lastExpr )
+                matchExpr.set_parse_action(pa)
+        thisExpr <<= (Group(matchExpr.set_name(termName)) | lastExpr )
         lastExpr = thisExpr
     ret <<= lastExpr
     return ret
 
 def nodeName(name):
-    return Empty().setParseAction(lambda: name).setResultsName('exprName')
+    return Empty().set_parse_action(lambda: name).set_results_name('exprName')
 
 def get_grammar():
     """Return the XULE grammar"""
     global INRESULT
     
-    ParserElement.enablePackrat()
+    ParserElement.enable_packrat()
     
     #comment = c_style_comment() | (Literal("//") + SkipTo(line_end()))
     comment = c_style_comment | (Literal("//") + SkipTo(line_end))
@@ -162,8 +162,8 @@ def get_grammar():
     lSquare = Literal('[')
     rSquare = Literal(']')
     bar = Literal('|')
-    coveredAspectStart = Literal('@').setParseAction(lambda s, l, t: 'covered')
-    uncoveredAspectStart = Literal('@@').setParseAction(lambda s, l, t: 'uncovered')
+    coveredAspectStart = Literal('@').set_parse_action(lambda s, l, t: 'covered')
+    uncoveredAspectStart = Literal('@@').set_parse_action(lambda s, l, t: 'uncovered')
     propertyOp = Literal('.')
     assignOp = Literal('=')
     asOp = CaselessKeyword('as')
@@ -186,7 +186,7 @@ def get_grammar():
     notOp = CaselessKeyword('not')
     andOp = CaselessKeyword('and')
     orOp = CaselessKeyword('or')
-    notInOp = Combine(notOp + White().setParseAction(lambda: ' ') + inOp)
+    notInOp = Combine(notOp + White().set_parse_action(lambda: ' ') + inOp)
     compOp = one_of('== != <= < >= >') | inOp | notInOp
     
     #numeric literals
@@ -195,57 +195,57 @@ def get_grammar():
     decimalPoint = CaselessLiteral(".")
     digits = Word(nums)
     integerPart = Combine(Opt(sign) + digits)
-    integerLiteral = Group(integerPart.setResultsName("value") +
+    integerLiteral = Group(integerPart.set_results_name("value") +
                       nodeName('integer'))
     infLiteral = Combine(Opt(sign) + CaselessKeyword("INF"))
     floatLiteral = Group((Combine(decimalPoint + digits + Opt(sciNot + integerPart)) |
                      Combine(integerPart + decimalPoint + 
                              ~CharsNotIn('0123456789') + ~(sciNot + ~integerPart) # This prevents matching a property of a literal number
                              + Opt(digits, default='0') + Opt(sciNot + integerPart)) |
-                     infLiteral).setResultsName("value") +
+                     infLiteral).set_results_name("value") +
                     nodeName('float'))
     #string literals
-#     stringLiteral = Group(((QuotedString("'", multiline=True, unquoteResults=False, escChar="\\").setParseAction(removeQuotes)  | 
-#                       QuotedString('"', multiline=True, unquoteResults=False, escChar="\\").setParseAction(removeQuotes)).setResultsName("value")) +
+#     stringLiteral = Group(((QuotedString("'", multiline=True, unquoteResults=False, escChar="\\").set_parse_action(remove_quotes)  | 
+#                       QuotedString('"', multiline=True, unquoteResults=False, escChar="\\").set_parse_action(remove_quotes)).set_results_name("value")) +
 #                      nodeName('string'))
     
-    stringEscape = Group(Suppress(Literal('\\')) + Regex('.').setResultsName('value') + nodeName('escape'))
+    stringEscape = Group(Suppress(Literal('\\')) + Regex('.').set_results_name('value') + nodeName('escape'))
     stringExpr = Suppress(Literal('{')) + blockExpr + Suppress(Literal('}'))
-    singleQuoteString = Suppress(Literal("'")) + ZeroOrMore(stringEscape | stringExpr | Group(Combine(OneOrMore(Regex("[^\\\\'{]"))).setResultsName('value') + nodeName('baseString'))) + Suppress(Literal("'"))
-    doubleQuoteString = Suppress(Literal('"')) + ZeroOrMore(stringEscape | stringExpr | Group(Combine(OneOrMore(Regex('[^\\\\"{]'))).setResultsName('value') + nodeName('baseString'))) + Suppress(Literal('"'))
-    stringLiteral = Group((Suppress(Opt(White())) + Group(singleQuoteString | doubleQuoteString).setResultsName('stringList') + Suppress(Opt(White())) + nodeName('string'))).leaveWhitespace()
+    singleQuoteString = Suppress(Literal("'")) + ZeroOrMore(stringEscape | stringExpr | Group(Combine(OneOrMore(Regex("[^\\\\'{]"))).set_results_name('value') + nodeName('baseString'))) + Suppress(Literal("'"))
+    doubleQuoteString = Suppress(Literal('"')) + ZeroOrMore(stringEscape | stringExpr | Group(Combine(OneOrMore(Regex('[^\\\\"{]'))).set_results_name('value') + nodeName('baseString'))) + Suppress(Literal('"'))
+    stringLiteral = Group((Suppress(Opt(White())) + Group(singleQuoteString | doubleQuoteString).set_results_name('stringList') + Suppress(Opt(White())) + nodeName('string'))).leave_whitespace()
 
     #boolean literals
-    booleanLiteral = Group((CaselessKeyword("true") | CaselessKeyword("false")).setResultsName("value") + nodeName('boolean'))
+    booleanLiteral = Group((CaselessKeyword("true") | CaselessKeyword("false")).set_results_name("value") + nodeName('boolean'))
     
     #none literal
-    noneLiteral = Group(CaselessKeyword("none").setResultsName('value') + nodeName('none'))
-    skipLiteral = Group(CaselessKeyword("skip").setResultsName('value') + nodeName('none'))
+    noneLiteral = Group(CaselessKeyword("none").set_results_name('value') + nodeName('none'))
+    skipLiteral = Group(CaselessKeyword("skip").set_results_name('value') + nodeName('none'))
     
     #severity literals  
     errorLiteral = CaselessKeyword("error")
     warningLiteral = CaselessKeyword("warning")
     okLiteral = CaselessKeyword("ok")
     passLiteral = CaselessKeyword("pass")
-    severityLiteral = Group((errorLiteral | warningLiteral | okLiteral | passLiteral).setResultsName('value') + nodeName('severity'))
+    severityLiteral = Group((errorLiteral | warningLiteral | okLiteral | passLiteral).set_results_name('value') + nodeName('severity'))
     
     #balance literals
-    balanceLiteral = Group((CaselessKeyword('debit') | CaselessKeyword('credit')).setResultsName('value') + nodeName('balance'))
-    periodTypeLiteral = Group((CaselessKeyword('instant') | CaselessKeyword('duration')).setResultsName('value') + nodeName('periodType'))
+    balanceLiteral = Group((CaselessKeyword('debit') | CaselessKeyword('credit')).set_results_name('value') + nodeName('balance'))
+    periodTypeLiteral = Group((CaselessKeyword('instant') | CaselessKeyword('duration')).set_results_name('value') + nodeName('periodType'))
 
 
     #forever literal
-    foreverLiteral = Group(Suppress(CaselessKeyword('forever')) + Empty().setParseAction(lambda s, l, t: True).setResultsName('forever') + nodeName('period'))
+    foreverLiteral = Group(Suppress(CaselessKeyword('forever')) + Empty().set_parse_action(lambda s, l, t: True).set_results_name('forever') + nodeName('period'))
 
     #direction keywords
-    directionLiteral = ((CaselessKeyword('ancestors').setResultsName('direction') + Opt(digits, -1).setResultsName('depth')) |  
-                        (CaselessKeyword('descendants').setResultsName('direction')  + Opt(digits, -1).setResultsName('depth')) | 
-                        CaselessKeyword('parents').setResultsName('direction') |
-                        CaselessKeyword('children').setResultsName('direction') |
-                        CaselessKeyword('siblings').setResultsName('direction') | 
-                        CaselessKeyword('previous-siblings').setResultsName('direction') | 
-                        CaselessKeyword('following-siblings').setResultsName('direction') | 
-                        CaselessKeyword('self').setResultsName('direction'))
+    directionLiteral = ((CaselessKeyword('ancestors').set_results_name('direction') + Opt(digits, -1).set_results_name('depth')) |  
+                        (CaselessKeyword('descendants').set_results_name('direction')  + Opt(digits, -1).set_results_name('depth')) | 
+                        CaselessKeyword('parents').set_results_name('direction') |
+                        CaselessKeyword('children').set_results_name('direction') |
+                        CaselessKeyword('siblings').set_results_name('direction') | 
+                        CaselessKeyword('previous-siblings').set_results_name('direction') | 
+                        CaselessKeyword('following-siblings').set_results_name('direction') | 
+                        CaselessKeyword('self').set_results_name('direction'))
     
     qNameOp = Literal(":")
     ncName = Regex("([A-Za-z\xC0-\xD6\xD8-\xF6\xF8-\xFF\u0100-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD_]"
@@ -267,94 +267,94 @@ def get_grammar():
                            "([A-Za-z0-9\xC0-\xD6\xD8-\xF6\xF8-\xFF\u0100-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF"
                            "\uF900-\uFDCF\uFDF0-\uFFFD\u0300-\u036F\u203F-\u2040\xB7_-]|(\\\.))"
                            "*)"
-                  ).setParseAction(lambda s, l, t: [t[0].replace('\\','')]) #parse action removes the escape backslash character
+                  ).set_parse_action(lambda s, l, t: [t[0].replace('\\','')]) #parse action removes the escape backslash character
     prefix = qNameLocalName
 
-    qName = Group(Opt(Combine(prefix + ~White() + Suppress(qNameOp)), default="*").setResultsName("prefix") + 
+    qName = Group(Opt(Combine(prefix + ~White() + Suppress(qNameOp)), default="*").set_results_name("prefix") + 
                   ~White() 
-                  + qNameLocalName.setResultsName("localName")
+                  + qNameLocalName.set_results_name("localName")
                   + nodeName('qname'))
 
-    tagOp = Literal('#').setParseAction(lambda: True).setResultsName('tagged')
-    tagName = simpleName.setResultsName('tagName')
+    tagOp = Literal('#').set_parse_action(lambda: True).set_results_name('tagged')
+    tagName = simpleName.set_results_name('tagName')
 
-    covered = CaselessKeyword('covered').setParseAction(lambda: True).setResultsName('covered')
-    coveredDims = CaselessKeyword('covered-dims').setParseAction(lambda: True).setResultsName('coveredDims')
-    includeNils = CaselessKeyword('nils').setParseAction(lambda: True).setResultsName('includeNils')
-    excludeNils = CaselessKeyword('nonils').setParseAction(lambda: True).setResultsName('excludeNils')
-    nilDefault = CaselessKeyword('nildefault').setParseAction(lambda: True).setResultsName('nilDefault')
+    covered = CaselessKeyword('covered').set_parse_action(lambda: True).set_results_name('covered')
+    coveredDims = CaselessKeyword('covered-dims').set_parse_action(lambda: True).set_results_name('coveredDims')
+    includeNils = CaselessKeyword('nils').set_parse_action(lambda: True).set_results_name('includeNils')
+    excludeNils = CaselessKeyword('nonils').set_parse_action(lambda: True).set_results_name('excludeNils')
+    nilDefault = CaselessKeyword('nildefault').set_parse_action(lambda: True).set_results_name('nilDefault')
     where = CaselessKeyword('where')
     returns = CaselessKeyword('returns')
 
     #variable reference
-    varRef = Group(Suppress(varIndicator) + simpleName.setResultsName('varName') + Empty().setParseAction(lambda: 'tagRef' if INRESULT else 'varRef').setResultsName('exprName'))
+    varRef = Group(Suppress(varIndicator) + simpleName.set_results_name('varName') + Empty().set_parse_action(lambda: 'tagRef' if INRESULT else 'varRef').set_results_name('exprName'))
 
     properties = Group(OneOrMore(Group(Suppress(propertyOp) +
-                                       simpleName.setResultsName('propertyName') +
+                                       simpleName.set_results_name('propertyName') +
                                        Opt(Group(Suppress(lParen) +
                                                 Opt(delimited_list(blockExpr)) +
                                                 Suppress(rParen)
-                                                ).setResultsName('propertyArgs')
+                                                ).set_results_name('propertyArgs')
                                                 
                                                 ) +
                                        Opt(tagOp + tagName)
                                        + nodeName('property')
                                  ))
-                       ).setResultsName('properties')
+                       ).set_results_name('properties')
 
 
-    whereClause = Suppress(where) + blockExpr.setResultsName('whereExpr')
-    returnsClause = Suppress(returns) + blockExpr.setResultsName('returnsExpr')
+    whereClause = Suppress(where) + blockExpr.set_results_name('whereExpr')
+    returnsClause = Suppress(returns) + blockExpr.set_results_name('returnsExpr')
 
     # Note the order of uncovered and covered is important. The uncovered must go first because it is a @@
     # while the coveted is a single @. If the order is flipped, the parser will think a @@ is two consecute
     # single @s instead of a single double @.
-    aspectStart = (uncoveredAspectStart | coveredAspectStart).setResultsName('coverType') + ~coveredAspectStart + ~White()
+    aspectStart = (uncoveredAspectStart | coveredAspectStart).set_results_name('coverType') + ~coveredAspectStart + ~White()
     
-    aspectNameLiteral = Group((CaselessKeyword('concept').setResultsName('value') | 
-                               CaselessKeyword('unit').setResultsName('value') | 
-                               CaselessKeyword('entity').setResultsName('value') | 
-                               CaselessKeyword('period').setResultsName('value') | 
-                               CaselessKeyword('instance').setResultsName('value') |
-                               CaselessKeyword('cube').setResultsName('value')) + nodeName('aspectName')
+    aspectNameLiteral = Group((CaselessKeyword('concept').set_results_name('value') | 
+                               CaselessKeyword('unit').set_results_name('value') | 
+                               CaselessKeyword('entity').set_results_name('value') | 
+                               CaselessKeyword('period').set_results_name('value') | 
+                               CaselessKeyword('instance').set_results_name('value') |
+                               CaselessKeyword('cube').set_results_name('value')) + nodeName('aspectName')
                               )
     
-    aspectName = ((aspectNameLiteral.setResultsName('aspectName') +
+    aspectName = ((aspectNameLiteral.set_results_name('aspectName') +
                     Opt(
-                             #properties.setResultsName('aspectProperties'))
+                             #properties.set_results_name('aspectProperties'))
                          Suppress(propertyOp) +
-                         ncName.setResultsName('propertyName') +
+                         ncName.set_results_name('propertyName') +
                          Opt(Group(Suppress(lParen) +
                                         Opt(delimited_list(blockExpr)) +
                                         Suppress(rParen)
-                                        ).setResultsName('propertyArgs')
+                                        ).set_results_name('propertyArgs')
                          )                        
                      )
                    )| 
-                   qName.setResultsName('aspectName') | 
-                   varRef.setResultsName('aspectName')
+                   qName.set_results_name('aspectName') | 
+                   varRef.set_results_name('aspectName')
                   )
     
     aspectOp = assignOp | Literal('!=') | inOp | notInOp
     
     aspectFilter = (aspectStart + 
                     aspectName +
-                             Opt(aspectOp.setResultsName('aspectOperator') + 
-                                      (Literal('*').setResultsName('wildcard') |
-                                       blockExpr.setResultsName('aspectExpr')
+                             Opt(aspectOp.set_results_name('aspectOperator') + 
+                                      (Literal('*').set_results_name('wildcard') |
+                                       blockExpr.set_results_name('aspectExpr')
                                       )
                                       ) +
-                             Opt(Suppress(asOp) + Suppress(varIndicator) + ~White()+ simpleName.setResultsName('alias'))
+                             Opt(Suppress(asOp) + Suppress(varIndicator) + ~White()+ simpleName.set_results_name('alias'))
                              
                     + nodeName('aspectFilter'))
     
     factsetInner =  ((Opt(excludeNils | includeNils) &
                     Opt(coveredDims) +
                     Opt(covered)) + 
-#                   (ZeroOrMore(Group(aspectFilter)).setResultsName('aspectFilters') ) +
-                    Opt((Suppress(Literal('@')) ^ OneOrMore(Group(aspectFilter)).setResultsName('aspectFilters'))) +
-#                     Opt((whereClause) | blockExpr.setResultsName('innerExpr')
-                    Opt(~ where + blockExpr.setResultsName('innerExpr') ) +
+#                   (ZeroOrMore(Group(aspectFilter)).set_results_name('aspectFilters') ) +
+                    Opt((Suppress(Literal('@')) ^ OneOrMore(Group(aspectFilter)).set_results_name('aspectFilters'))) +
+#                     Opt((whereClause) | blockExpr.set_results_name('innerExpr')
+                    Opt(~ where + blockExpr.set_results_name('innerExpr') ) +
                     Opt(whereClause)
                     )
                     
@@ -365,27 +365,27 @@ def get_grammar():
                       Suppress(lCurly) + 
                       factsetInner +                    
                       Suppress(rCurly) +
-                      Empty().setParseAction(lambda s, l, t: 'open').setResultsName('factsetType')
+                      Empty().set_parse_action(lambda s, l, t: 'open').set_results_name('factsetType')
                       ) |
                      (
                       Suppress(lSquare) + 
                       factsetInner +                    
                       Suppress(rSquare) +
-                      Empty().setParseAction(lambda s, l, t: 'closed').setResultsName('factsetType')
+                      Empty().set_parse_action(lambda s, l, t: 'closed').set_results_name('factsetType')
                       ) |
                       (Opt(excludeNils | includeNils) +
                       Opt(nilDefault) +
                       Opt(covered) +
-                      (Suppress(Literal('@')) ^ OneOrMore(Group(aspectFilter)).setResultsName('aspectFilters')) + #This is a factset without enclosing brackets
-                      Empty().setParseAction(lambda s, l, t: 'open').setResultsName('factsetType') +
+                      (Suppress(Literal('@')) ^ OneOrMore(Group(aspectFilter)).set_results_name('aspectFilters')) + #This is a factset without enclosing brackets
+                      Empty().set_parse_action(lambda s, l, t: 'open').set_results_name('factsetType') +
                       Opt(whereClause))
                 ) +
                 nodeName('factset')        
             )
     
-    returnComponents = (Group(simpleName).setResultsName('returnComponents') |
+    returnComponents = (Group(simpleName).set_results_name('returnComponents') |
                         (Suppress('(') +
-                         Group(delimited_list(simpleName + ~Literal(':') | blockExpr)).setResultsName('returnComponents') +
+                         Group(delimited_list(simpleName + ~Literal(':') | blockExpr)).set_results_name('returnComponents') +
                          Suppress(')'))
                         )
     
@@ -394,69 +394,69 @@ def get_grammar():
                        # The dimension and arcrole need the FollowedBy() look ahead. I'm not sure why, but it is because these are optional and the direction is reuired.
                        # Without the FollowedBy() look ahead, 'navigate self' fails because the parser thinks 'navigate' is a qname and then does not know what to 
                        # do with 'self'.
-                       Opt(CaselessKeyword('dimensions').setParseAction(lambda: True).setResultsName('dimensional') + (FollowedBy(blockExpr | directionLiteral) )) +
-                       Opt(blockExpr.setResultsName('arcrole') + FollowedBy(directionLiteral)) +  
+                       Opt(CaselessKeyword('dimensions').set_parse_action(lambda: True).set_results_name('dimensional') + (FollowedBy(blockExpr | directionLiteral) )) +
+                       Opt(blockExpr.set_results_name('arcrole') + FollowedBy(directionLiteral)) +  
                        directionLiteral +
-                       Opt(Group(CaselessKeyword('include') + CaselessKeyword('start')).setParseAction(lambda: True).setResultsName('includeStart')) +
-                       Opt(Suppress(CaselessKeyword('from')) + blockExpr.setResultsName('from')) +
-                       Opt(Suppress(CaselessKeyword('to')) + blockExpr.setResultsName('to')) +
-                       Opt(Suppress(Group(CaselessKeyword('stop') + CaselessKeyword('when'))) + blockExpr.setResultsName('stopExpr')) +
-                       Opt(Suppress(CaselessKeyword('role')) + blockExpr.setResultsName('role')) +
-                       Opt(Suppress(CaselessKeyword('drs-role')) + blockExpr.setResultsName('drsRole')) +
-                       Opt(Suppress(CaselessKeyword('linkbase')) + blockExpr.setResultsName('linkbase')) +
-                       Opt(Suppress(CaselessKeyword('cube')) + blockExpr.setResultsName('cube')) +
-                       Opt(Suppress(CaselessKeyword('taxonomy')) + blockExpr.setResultsName('taxonomy')) +
+                       Opt(Group(CaselessKeyword('include') + CaselessKeyword('start')).set_parse_action(lambda: True).set_results_name('includeStart')) +
+                       Opt(Suppress(CaselessKeyword('from')) + blockExpr.set_results_name('from')) +
+                       Opt(Suppress(CaselessKeyword('to')) + blockExpr.set_results_name('to')) +
+                       Opt(Suppress(Group(CaselessKeyword('stop') + CaselessKeyword('when'))) + blockExpr.set_results_name('stopExpr')) +
+                       Opt(Suppress(CaselessKeyword('role')) + blockExpr.set_results_name('role')) +
+                       Opt(Suppress(CaselessKeyword('drs-role')) + blockExpr.set_results_name('drsRole')) +
+                       Opt(Suppress(CaselessKeyword('linkbase')) + blockExpr.set_results_name('linkbase')) +
+                       Opt(Suppress(CaselessKeyword('cube')) + blockExpr.set_results_name('cube')) +
+                       Opt(Suppress(CaselessKeyword('taxonomy')) + blockExpr.set_results_name('taxonomy')) +
                        Opt(whereClause) +
                        Opt(Group(
                                       Suppress(CaselessKeyword('returns')) +
-                                      Opt(Group(CaselessKeyword('by') + CaselessKeyword('network')).setParseAction(lambda: True).setResultsName('byNetwork')) +                                    
+                                      Opt(Group(CaselessKeyword('by') + CaselessKeyword('network')).set_parse_action(lambda: True).set_results_name('byNetwork')) +                                    
                                       Opt(
                                              CaselessKeyword('list') |
                                              CaselessKeyword('set') 
-                                             ).setResultsName('returnType') +
-                                      Opt(CaselessKeyword('paths').setParseAction(lambda: True).setResultsName('paths')) +
+                                             ).set_results_name('returnType') +
+                                      Opt(CaselessKeyword('paths').set_parse_action(lambda: True).set_results_name('paths')) +
                                       Opt(returnComponents +
-                                               Opt(Suppress(CaselessKeyword('as')) + CaselessKeyword('dictionary').setResultsName('returnComponentType'))) +
+                                               Opt(Suppress(CaselessKeyword('as')) + CaselessKeyword('dictionary').set_results_name('returnComponentType'))) +
                                       nodeName('returnExpr')
-                                ).setResultsName('return')
+                                ).set_results_name('return')
                         ) +
                        nodeName('navigation')
                 )
     
     filter = Group(
                    Suppress(CaselessKeyword('filter')) +
-                   blockExpr.setResultsName('expr') + 
+                   blockExpr.set_results_name('expr') + 
                    Opt(whereClause) +
                    Opt(returnsClause) +
                    nodeName('filter')
                    )
     #function reference
-    funcRef = Group(simpleName.setResultsName("functionName") + ~White() +
+    funcRef = Group(simpleName.set_results_name("functionName") + ~White() +
                     Suppress(lParen) + 
                     Group(Opt(delimited_list(blockExpr)  +
                                    Opt(Suppress(commaOp)) #This allows a trailing comma for lists and sets
-                                   )).setResultsName("functionArgs") + 
+                                   )).set_results_name("functionArgs") + 
                 Suppress(rParen) +
                 nodeName('functionReference')) 
 
     #if expression
     elseIfExpr = (OneOrMore(Group(Suppress(elseOp + ifOp) + 
-                                    blockExpr.setResultsName("condition") +
-                                    blockExpr.setResultsName("thenExpr") +
+                                    blockExpr.set_results_name("condition") +
+                                    blockExpr.set_results_name("thenExpr") +
                                     nodeName('elseIf')
                                     )
-                              ).setResultsName("elseIfExprs")
+                              ).set_results_name("elseIfExprs")
                    )
 
     ifExpr = Group(Suppress(ifOp) + 
                    
-                   blockExpr.setResultsName("condition") + 
+                   blockExpr.set_results_name("condition") + 
                    
-                   blockExpr.setResultsName("thenExpr") +
+                   blockExpr.set_results_name("thenExpr") +
                    # this will flatten nested if conditions 
                    Opt(elseIfExpr) +
                    Suppress(elseOp) + 
-                   blockExpr.setResultsName("elseExpr") +
+                   blockExpr.set_results_name("elseExpr") +
                    nodeName('ifExpr')
               ) 
               
@@ -464,22 +464,22 @@ def get_grammar():
                ((Suppress(forOp) + 
                 #for loop control: for var name and loop expression
                 Suppress(lParen) + 
-                Combine(Suppress(varIndicator) + ~White() + simpleName.setResultsName("forVar")) + 
+                Combine(Suppress(varIndicator) + ~White() + simpleName.set_results_name("forVar")) + 
                 Suppress(inOp) + 
-                blockExpr.setResultsName("forLoopExpr") +
+                blockExpr.set_results_name("forLoopExpr") +
                 Suppress(rParen) +
                 #for body expression
-                blockExpr.setResultsName("forBodyExpr") + 
+                blockExpr.set_results_name("forBodyExpr") + 
                 nodeName('forExpr'))) |
                
                #without parens around the for control
                ((Suppress(forOp) + 
                 #for loop control
-                Combine(Suppress(varIndicator) + ~White() + simpleName.setResultsName("forVar")) + 
+                Combine(Suppress(varIndicator) + ~White() + simpleName.set_results_name("forVar")) + 
                 Suppress(inOp) + 
-                blockExpr.setResultsName("forLoopExpr") +
+                blockExpr.set_results_name("forLoopExpr") +
                 #for body expression
-                blockExpr.setResultsName("forBodyExpr") + 
+                blockExpr.set_results_name("forBodyExpr") + 
                 nodeName('forExpr')))
                )
     
@@ -487,23 +487,23 @@ def get_grammar():
                         Suppress(lParen) +
                         Group(Opt(delimited_list(blockExpr) +
                                        Opt(Suppress(commaOp)) #This allows a trailing comma for lists and sets
-                                       )).setResultsName("functionArgs") + 
+                                       )).set_results_name("functionArgs") + 
                         Suppress(rParen) +
                         nodeName('functionReference') +
                        
-                       Empty().setParseAction(lambda s, l, t: "list").setResultsName("functionName")
+                       Empty().set_parse_action(lambda s, l, t: "list").set_results_name("functionName")
                        )
     
     #dictExpr = Group(Suppress(CaselessKeyword('dict')) +
-    #                 Group(delimited_list(Group(blockExpr.setResultsName('key') + Literal('=') + blockExpr.setResultsName('value') + nodeName('item')))).setResultsName('items') +
+    #                 Group(delimited_list(Group(blockExpr.set_results_name('key') + Literal('=') + blockExpr.set_results_name('value') + nodeName('item')))).set_results_name('items') +
     #                 nodeName('dictExpr'))
     #
     #listExpr = Group(Suppress(CaselessKeyword('list')) +
-    #                 Group(delimited_list(blockExpr)).setResultsName('items') +
+    #                 Group(delimited_list(blockExpr)).set_results_name('items') +
     #                 nodeName('listExpr'))
     #
     #setExpr = Group(Suppress(CaselessKeyword('set')) +
-    #                Group(delimited_list(blockExpr)).setResultsName('items') +
+    #                Group(delimited_list(blockExpr)).set_results_name('items') +
     #                nodeName('setExpr'))
     
     atom = (
@@ -547,19 +547,19 @@ def get_grammar():
     #expressions with precedence.
     #taggedExpr = (Group(atom) + Suppress('#') + tagName + nodeName('taggedExpr')) | atom
     
-    taggedExpr = Group(atom.setResultsName('expr') + Suppress('#') + tagName + nodeName('taggedExpr')) | atom
+    taggedExpr = Group(atom.set_results_name('expr') + Suppress('#') + tagName + nodeName('taggedExpr')) | atom
         
-#     unaryExpr = Group(unaryOp.setResultsName('op') + 
+#     unaryExpr = Group(unaryOp.set_results_name('op') + 
 #                        #~digits + ~CaselessLiteral('INF') + 
-#                        Group(taggedExpr).setResultsName('expr') +
+#                        Group(taggedExpr).set_results_name('expr') +
 #                       nodeName('unaryExpr')) | taggedExpr
                        
-    indexExpr = Group(taggedExpr.setResultsName('expr') +
+    indexExpr = Group(taggedExpr.set_results_name('expr') +
                       OneOrMore((Suppress(lSquare) + blockExpr + 
-                                      Suppress(rSquare) )).setResultsName('indexes') +
+                                      Suppress(rSquare) )).set_results_name('indexes') +
                       nodeName('indexExpr')) | taggedExpr
     
-    propertyExpr = Group(indexExpr.setResultsName('expr') +
+    propertyExpr = Group(indexExpr.set_results_name('expr') +
                          properties +
                          nodeName('propertyExpr')) | indexExpr
      
@@ -577,16 +577,16 @@ def get_grammar():
 
     varDeclaration = (
                            Suppress(varIndicator) + ~White() +
-                           simpleName.setResultsName('varName') +   
+                           simpleName.set_results_name('varName') +   
                            Opt(tagOp +
                                     Opt(tagName)) + 
                            Suppress('=') +
-                           blockExpr.setResultsName('body') + Opt(Suppress(';')) +
+                           blockExpr.set_results_name('body') + Opt(Suppress(';')) +
                            nodeName('varDeclaration')
                            )
 
-    blockExpr << (Group((OneOrMore(Group(varDeclaration)).setResultsName('varDeclarations') + 
-                        expr.setResultsName('expr') +
+    blockExpr << (Group((OneOrMore(Group(varDeclaration)).set_results_name('varDeclarations') + 
+                        expr.set_results_name('expr') +
                         nodeName('blockExpr'))) | expr)
     
     #nsURI is based on XML char (http://www.w3.org/TR/xml11/#NT-Char) excluding the space character
@@ -620,94 +620,94 @@ def get_grammar():
                                  (
                                   #The prefix is optional. This either matches when the prefix is there or empty to capture the default.
                                   (
-                                   prefix.setResultsName('prefix') +
+                                   prefix.set_results_name('prefix') +
                                    Suppress(Literal('='))
                                    ) |
-                                  Empty().setParseAction(lambda s, l, tok: '*').setResultsName('prefix')
+                                  Empty().set_parse_action(lambda s, l, tok: '*').set_results_name('prefix')
                                   ) +
-                                 nsURI.setResultsName('namespaceURI') +
+                                 nsURI.set_results_name('namespaceURI') +
                                  nodeName('nsDeclaration')
                                  )
 
 #     outputAttributeDeclaration = Group(
 #                                        Suppress(outputAttributeKeyword) +
-#                                        simpleName.setResultsName('attributeName')).setResultsName('outputAttributeDeclaration')
+#                                        simpleName.set_results_name('attributeName')).set_results_name('outputAttributeDeclaration')
 
     outputAttributeDeclaration = (
                                    Suppress(outputAttributeKeyword) +
-                                   simpleName.setResultsName('attributeName') +
+                                   simpleName.set_results_name('attributeName') +
                                    nodeName('outputAttributeDeclaration')
                                  )
     
     ruleNamePrefix = (
                       Suppress(ruleNamePrefixKeyword) +
-                      ncName.setResultsName('prefix') +
+                      ncName.set_results_name('prefix') +
                       nodeName('ruleNamePrefix')
                       )
     
     ruleNameSeparator = (
                          Suppress(ruleNameSeparatorKeyword) +
-                         Word(printables).setResultsName('separator') +
+                         Word(printables).set_results_name('separator') +
                          nodeName('ruleNameSeparator')
                          )
     
     ruleResult = Group( ~declarationKeywords +
-                         (CaselessKeyword('message') | CaselessKeyword('severity') | CaselessKeyword('rule-suffix') | CaselessKeyword('rule-focus') | simpleName).setResultsName('resultName') + Empty().setParseAction(in_result) +
-                         expr.setResultsName('resultExpr').setParseAction(out_result).setFailAction(out_result) + nodeName('result')
+                         (CaselessKeyword('message') | CaselessKeyword('severity') | CaselessKeyword('rule-suffix') | CaselessKeyword('rule-focus') | simpleName).set_results_name('resultName') + Empty().set_parse_action(in_result) +
+                         expr.set_results_name('resultExpr').set_parse_action(out_result).set_fail_action(out_result) + nodeName('result')
                     )
 
     assertDeclaration = (
                               Suppress(assertKeyword) +
-                              ncName.setResultsName('ruleName') +
-                              Opt(CaselessKeyword('satisfied') | CaselessKeyword('unsatisfied'), default='satisfied').setResultsName('satisfactionType') +
-                              blockExpr.setResultsName('body') +
-                              ZeroOrMore(ruleResult).setResultsName('results') +
+                              ncName.set_results_name('ruleName') +
+                              Opt(CaselessKeyword('satisfied') | CaselessKeyword('unsatisfied'), default='satisfied').set_results_name('satisfactionType') +
+                              blockExpr.set_results_name('body') +
+                              ZeroOrMore(ruleResult).set_results_name('results') +
                               nodeName('assertion')
                               )
 
     outputDeclaration = (
                               Suppress(outputKeyword) +
-                              ncName.setResultsName('ruleName') +
-                              blockExpr.setResultsName('body') +
-                              ZeroOrMore(ruleResult).setResultsName('results') +
+                              ncName.set_results_name('ruleName') +
+                              blockExpr.set_results_name('body') +
+                              ZeroOrMore(ruleResult).set_results_name('results') +
                               nodeName('outputRule')
                               )
 
     constantDeclaration = (
                   Suppress(constantKeyword) +
                   Suppress(varIndicator) + ~ White() +
-                  simpleName.setResultsName("constantName") + 
+                  simpleName.set_results_name("constantName") + 
                   Opt(tagOp +
                            Opt(tagName)) + 
                   Suppress(assignOp) + 
-                  expr.setResultsName("body") +
+                  expr.set_results_name("body") +
                   nodeName('constantDeclaration')
             )                            
 
     namespaceGroupDeclaration = (
                   Suppress(namespaceGroupKeyword) +
-                  simpleName.setResultsName("namespaceGroupName") + 
+                  simpleName.set_results_name("namespaceGroupName") + 
                   Suppress(assignOp) + 
-                  expr.setResultsName("body") +
+                  expr.set_results_name("body") +
                   nodeName('namespaceGroupDeclaration')
             )  
 
     functionDeclaration = (
         Suppress(functionKeyword) + 
-        simpleName.setResultsName("functionName") + ~White() +
+        simpleName.set_results_name("functionName") + ~White() +
         Suppress(lParen) + 
-        Group(Opt(delimited_list(Group(Suppress(varIndicator) + ~White() + simpleName.setResultsName('argName') + nodeName('functionArg') + 
+        Group(Opt(delimited_list(Group(Suppress(varIndicator) + ~White() + simpleName.set_results_name('argName') + nodeName('functionArg') + 
                                            Opt(tagOp +
                                                     Opt(tagName)))) +
                        Opt(Suppress(commaOp)) #This allows a trailing comma for lists and sets
-        )).setResultsName("functionArgs") + 
+        )).set_results_name("functionArgs") + 
         Suppress(rParen) +
-        blockExpr.setResultsName("body") +
+        blockExpr.set_results_name("body") +
         nodeName('functionDeclaration')
         )
 
     versionDeclaration = (
-            Suppress(versionKeyword) + Word(printables).setResultsName('version') + nodeName('versionDeclaration')
+            Suppress(versionKeyword) + Word(printables).set_results_name('version') + nodeName('versionDeclaration')
     )
 
     xuleFile = (string_start +
@@ -721,9 +721,9 @@ def get_grammar():
                                  versionDeclaration |
                                  assertDeclaration |
                                  outputDeclaration)) +
-                string_end).setResultsName('xuleDoc').ignore(comment)
-    #xuleFile = Group(ZeroOrMore(factset)).setResultsName('xuleDoc')
+                string_end).set_results_name('xuleDoc').ignore(comment)
+    #xuleFile = Group(ZeroOrMore(factset)).set_results_name('xuleDoc')
     
-    #xuleFile = (string_start + Opt(header) + ZeroOrMore(packageBody) + string_end).setResultsName("xule").ignore(comment)
+    #xuleFile = (string_start + Opt(header) + ZeroOrMore(packageBody) + string_end).set_results_name("xule").ignore(comment)
     
     return xuleFile


### PR DESCRIPTION
## Changes

1. The first two commits (5bbfbc7b22e9417f1322bac3ddc00d409aaceec0, 42eb6254662902e690b10b642fe22bc7dfe7c4f1) handle differences between grammar behavior in pyparsing 2 and 3.
2. The third commit (df4e8807ca647d94d2f0c91420aeda26d0ddb4ea) is general cleanup that removes unused pyparsing imports.
3. The fourth and fifth commits (532b7360d82e22db8b102dd9b20bd42edb9fe25c, a446399c68255fa8ae0ac123f58624622947e381) transition the grammar from using pyparsing classes and functions which have been deprecated in pyparsing 3 and slated for removed in pyparsing 4. While there's quite a bit here, it's all renaming `setResultsName()` to `set_results_name()`, `Optional(...)` to `Opt(...)`, etc. These two commits break compatibility with pyparsing 2 while the previous 3 do not.

## Testing

I compiled each of the ESEF, US, and IFRS DQC sources using the json format (`--xule-compile-type json`) with both the current main branch and pyparsing 2 and then with this updated PR and pyparsing 3. I then ran a diff between the json output to verify there were no changes in the compiled output.

@campbellpryde 
@davidtauriello 
