### PR TITLE
Add rule_name to args when an error occurs

### DIFF
--- a/plugin/xule/XuleMultiProcessing.py
+++ b/plugin/xule/XuleMultiProcessing.py
@@ -269,7 +269,7 @@ def rules_process(name, global_context, cq):
             if getattr(global_context.options, "xule_crash", False):
                 raise
             else:
-                xule_context.global_context.message_queue.error("xule:error", str(e))
+                xule_context.global_context.message_queue.error("xule:error", str(e), rule_name=rule_name)
 
         except XuleIterationStop:
             pass
@@ -278,7 +278,7 @@ def rules_process(name, global_context, cq):
             if getattr(global_context.options, "xule_crash", False):
                 raise
             else:
-                xule_context.global_context.message_queue.error("xule:error","rule %s: %s" % (rule_name, str(e)))        
+                xule_context.global_context.message_queue.error("xule:error", "rule %s: %s" % (rule_name, str(e)), rule_name=rule_name)
         
         if getattr(global_context.options, "xule_time", None) is not None:
             rule_end = datetime.datetime.today()

--- a/plugin/xule/XuleProcessor.py
+++ b/plugin/xule/XuleProcessor.py
@@ -203,7 +203,7 @@ def evaluate_rule_set(global_context):
                 if getattr(global_context.options, "xule_crash", False):
                     raise
                 else:
-                    xule_context.global_context.message_queue.error("xule:error", "rule %s: %s" % (rule_name, str(e)))
+                    xule_context.global_context.message_queue.error("xule:error", "rule %s: %s" % (rule_name, str(e)), rule_name=rule_name)
 
             except XuleIterationStop:
                 pass
@@ -213,7 +213,7 @@ def evaluate_rule_set(global_context):
                     # if global_context.crash_on_error:
                     raise
                 else:
-                    xule_context.global_context.message_queue.error("xule:error", "rule %s: %s" % (rule_name, str(e)))
+                    xule_context.global_context.message_queue.error("xule:error", "rule %s: %s" % (rule_name, str(e)), rule_name=rule_name)
 
             if getattr(global_context.options, "xule_time", None) is not None:
                 rule_end = datetime.datetime.today()


### PR DESCRIPTION
#### Description:
In order to give as much information to people around errors, include the rule name as an argument on all `xule:error` validations.

#### Testing:
Get an error to fire during the evaluation of a rule. The resulting validation json should include the `rule_name` as argument on the `xule:error` validation.

@campbellpryde
@davidtauriello