### PR TITLE
Add argument for compiling rule files in parallel

### DIFF
--- a/plugin/FERC/render.py
+++ b/plugin/FERC/render.py
@@ -1921,7 +1921,7 @@ def process_single_template(cntlr, options, template_catalog, template_set_file,
         # xule rule set name
         xule_rule_set_name = os.path.join(temp_dir, 'temp-ruleset.zip')
         compile_method = getXuleMethod(cntlr, 'Xule.compile')
-        compile_method(xule_rule_file_name, xule_rule_set_name, 'pickle', getattr(options, "xule_max_recurse_depth"))
+        compile_method(xule_rule_file_name, xule_rule_set_name, 'pickle', getattr(options, "xule_max_recurse_depth"), getattr(options, "xule_compile_workers"))
 
         template_catalog.append({'name': template_name,
                             'template': template_file_name,

--- a/plugin/xendr/xendrCompile.py
+++ b/plugin/xendr/xendrCompile.py
@@ -72,7 +72,7 @@ def process_single_template(cntlr, options, template_catalog, template_set_file,
         xule_rule_set_name = os.path.join(temp_dir, 'temp-ruleset.zip')
         from .xule import __pluginInfo__ as xule_plugin_info
         compile_method = xule_plugin_info['Xule.compile']
-        compile_method(xule_rule_file_name, xule_rule_set_name, 'pickle', getattr(options, "xule_max_recurse_depth"))
+        compile_method(xule_rule_file_name, xule_rule_set_name, 'pickle', getattr(options, "xule_max_recurse_depth"), getattr(options, "xule_compile_workers"))
 
         template_catalog.append({'name': template_name,
                             'template': template_file_name,

--- a/plugin/xule/XuleParseFile.py
+++ b/plugin/xule/XuleParseFile.py
@@ -1,0 +1,31 @@
+import datetime
+import os
+import sys
+import threading
+from queue import Queue
+
+from .xule_grammar import get_grammar
+
+
+def parseFile(full_file_name, stack_size, recursion_limit):
+    if threading.stack_size() != stack_size:
+        threading.stack_size(stack_size)
+    if sys.getrecursionlimit() < recursion_limit:
+        sys.setrecursionlimit(recursion_limit)
+    start_time = datetime.datetime.today()
+    file_name = os.path.basename(full_file_name)
+    print("%s: %s parse start" % (datetime.datetime.isoformat(start_time), file_name))
+
+    parseResQueue = Queue()
+
+    def threaded_parse():
+        xule_grammar = get_grammar()
+        parseRes = xule_grammar.parseFile(full_file_name).as_dict()
+        parseResQueue.put(parseRes)
+
+    threading.Thread(target=threaded_parse).start()
+    parseRes = parseResQueue.get()
+
+    end_time = datetime.datetime.today()
+    print("%s: %s parse end. Took %s" % (datetime.datetime.isoformat(end_time), file_name, end_time - start_time))
+    return parseRes

--- a/plugin/xule/XuleParser.py
+++ b/plugin/xule/XuleParser.py
@@ -32,6 +32,7 @@ import json
 import sys
 import hashlib
 import threading
+from pathlib import Path
 
 _options = None
 
@@ -76,7 +77,6 @@ def parseFile(fullFileName, fileHash, xuleGrammar, ruleSet):
 
         # Write the parse results as a josn file
         if hasattr(_options, 'xule_compile_save_pyparsing_result_location') and _options.xule_compile_save_pyparsing_result_location is not None:
-            from pathlib import Path
             pyparsing_result_file_name = f'{os.path.join(_options.xule_compile_save_pyparsing_result_location, fileName)}.pyparsed.json'
             Path(os.path.dirname(pyparsing_result_file_name)).mkdir(parents=True, exist_ok=True)
             with open(pyparsing_result_file_name, 'w') as py_write:
@@ -126,14 +126,9 @@ def parseRules(files, dest, compile_type, max_recurse_depth=None):
 
     # Set the stack size
     global _options
-    if _options is None or getattr(_options, 'xule_stack_size', None) is None:
-        #threading.stack_size(0x2000000)
-        threading.stack_size(8 * 1048576)
-    else:
-        threading.stack_size(getattr(_options, 'xule_stack_size') * 1048576)
-    
-    #threading.stack_size(0x2000000)
-    
+    stack_size = getattr(_options, 'xule_stack_size', 8) * 1048576
+    threading.stack_size(stack_size)
+
     #Need to check the recursion limit. 1000 is too small for some rules.
     new_depth = max_recurse_depth or 5500
     orig_recursionlimit = sys.getrecursionlimit()

--- a/plugin/xule/XuleParser.py
+++ b/plugin/xule/XuleParser.py
@@ -119,17 +119,17 @@ def parseFile(dir, fileName, xuleGrammar, ruleSet):
     return parse_errors
 
 def fixForPyParsing(parseRes):
-        if isinstance(parseRes, dict):
-            if isinstance(parseRes.get('expr'), list):
-                if len(parseRes['expr']) == 1:
-                    parseRes['expr'] = parseRes['expr'][0]
-                else:
-                    raise xrs.XuleRuleSetError("Unable to parse rules. Using a version of PyParsing later than 2.3.0 and cannot correct parse result\n")
-            for child in parseRes.values():
-                fixForPyParsing(child)
-        elif isinstance(parseRes, list) or isinstance(parseRes, set): # I don't think there will ever be a set, but this won't hurt.
-            for child in parseRes:
-                fixForPyParsing(child)
+    if isinstance(parseRes, dict):
+        if isinstance(parseRes.get('expr'), list):
+            if len(parseRes['expr']) == 1:
+                parseRes['expr'] = parseRes['expr'][0]
+            else:
+                raise xrs.XuleRuleSetError("Unable to parse rules. Using a version of PyParsing later than 2.3.0 and cannot correct parse result\n")
+        for child in parseRes.values():
+            fixForPyParsing(child)
+    elif isinstance(parseRes, list) or isinstance(parseRes, set): # I don't think there will ever be a set, but this won't hurt.
+        for child in parseRes:
+            fixForPyParsing(child)
 
 def parseRules(files, dest, compile_type, max_recurse_depth=None):
 

--- a/plugin/xule/__init__.py
+++ b/plugin/xule/__init__.py
@@ -24,6 +24,8 @@ limitations under the License.
 $Change: 23587 $
 DOCSKIP
 """
+import sys
+
 from .XuleProcessor import process_xule
 from . import XuleRunTime as xrt
 from . import XuleRuleSet as xr
@@ -444,6 +446,13 @@ def xuleCmdOptions(parser):
                                action="store",
                                help=_("This will save the result from pyparsing as a json file. This is the raw parse results before post parsing. Used for debugging purpsoses."))
 
+        parserGroup.add_option("--xule-compile-workers",
+                               action="store",
+                               dest="xule_compile_workers",
+                               default=1,
+                               type="int",
+                               help=_("Controls the number of worker processes used to compile XULE rule files in parallel. A value of 0 will use the number of machine processors."))
+
     parserGroup.add_option("--xule-rule-set",
                       action="store",
                       dest="xule_rule_set",
@@ -703,10 +712,20 @@ def xuleCmdUtilityRun(cntlr, options, **kwargs):
     if getattr(options, 'xule_max_excel_files') < 1:
         parser.error(_("--xule-max-excel-files must be greater than 0, found {}".format(getattr(options, 'xule_max_excel_files'))))
 
+    if getattr(options, 'xule_compile_workers') < 0:
+        parser.error(_("Workers (--xule-compile-workers) value must be a positive number or 0 (uses number of CPUs)."))
+    elif getattr(options, 'xule_compile_workers') != 1:
+        if getattr(sys, "frozen", False):
+            parser.error(_("Multiple workers (--xule-compile-workers) requires running Arelle from source."))
+        try:
+            from arelle.PluginUtils import PluginProcessPoolExecutor
+        except ModuleNotFoundError:
+            parser.error(_("Multiprocessing plugin support was introduced in Arelle 2.17.3. Update to a newer version of Arelle to use multiple workers (--xule-compile-workers)."))
+
     # compile rules
     if getattr(options, "xule_compile", None):
         compile_destination = getattr(options, "xule_rule_set", "xuleRules") 
-        xuleCompile(options.xule_compile, compile_destination, getattr(options, "xule_compile_type"), getattr(options, "xule_max_recurse_depth"))
+        xuleCompile(options.xule_compile, compile_destination, getattr(options, "xule_compile_type"), getattr(options, "xule_max_recurse_depth"), getattr(options, "xule_compile_workers"))
         #xp.parseRules(options.xule_compile.split("|"), compile_destination, getattr(options, "xule_compile_type"))
     
     # add packages
@@ -874,8 +893,8 @@ def xuleCmdXbrlLoaded(cntlr, options, modelXbrl, *args, **kwargs):
     if getattr(options, "xule_run", None):
         runXule(cntlr, options, modelXbrl)
 
-def xuleCompile(xule_file_names, ruleset_file_name, compile_type, max_recurse_depth=None):
-    xp.parseRules(xule_file_names.split("|"), ruleset_file_name, compile_type, max_recurse_depth)
+def xuleCompile(xule_file_names, ruleset_file_name, compile_type, max_recurse_depth=None, xule_compile_workers=1):
+    xp.parseRules(xule_file_names.split("|"), ruleset_file_name, compile_type, max_recurse_depth, xule_compile_workers)
 
 def runXule(cntlr, options, modelXbrl, rule_set_map=_xule_rule_set_map_name):
         try:

--- a/plugin/xule/xule_grammar.py
+++ b/plugin/xule/xule_grammar.py
@@ -29,15 +29,6 @@ from pyparsing import (Word, CaselessKeyword,
                  OneOrMore, one_of, c_style_comment, CharsNotIn,
                  line_end, White, SkipTo, Empty, string_start, string_end, printables)
 
-INRESULT = False
-
-def in_result():
-    global INRESULT
-    INRESULT = True
-
-def out_result(*args):
-    global INRESULT
-    INRESULT = False
 
 def buildPrecedenceExpressions( baseExpr, opList, lpar=Suppress('('), rpar=Suppress(')')):
     """Simplified and modified version of pyparsing infix_notation helper function
@@ -130,10 +121,19 @@ def nodeName(name):
 
 def get_grammar():
     """Return the XULE grammar"""
-    global INRESULT
-    
+
     ParserElement.enable_packrat()
-    
+
+    in_result_val = False
+
+    def in_result():
+        nonlocal in_result_val
+        in_result_val = True
+
+    def out_result(*args):
+        nonlocal in_result_val
+        in_result_val = False
+
     #comment = c_style_comment() | (Literal("//") + SkipTo(line_end()))
     comment = c_style_comment | (Literal("//") + SkipTo(line_end))
     
@@ -287,7 +287,7 @@ def get_grammar():
     returns = CaselessKeyword('returns')
 
     #variable reference
-    varRef = Group(Suppress(varIndicator) + simpleName.set_results_name('varName') + Empty().set_parse_action(lambda: 'tagRef' if INRESULT else 'varRef').set_results_name('exprName'))
+    varRef = Group(Suppress(varIndicator) + simpleName.set_results_name('varName') + Empty().set_parse_action(lambda: 'tagRef' if in_result_val else 'varRef').set_results_name('exprName'))
 
     properties = Group(OneOrMore(Group(Suppress(propertyOp) +
                                        simpleName.set_results_name('propertyName') +


### PR DESCRIPTION
This adds an argument (`--xule-compile-workers`) which can be used to specify the number of processes for compiling rules in parallel. The default value is `1` and a value of `0` will use the number of CPUs available on the system.

Precise performance improvements depend on the system and number of workers used. Using all cores (`--xule-compile-workers=0`) on my M1 MacBook Pro drops compile time for US GAAP 2023 from 1:32 mins to 0:27 and compiling all rule sets for all years of IFRS, US GAAP, and ESEF from 7:18 to 2:46.

We introduced code in Arelle [2.17.3](https://github.com/Arelle/Arelle/releases/tag/2.17.3) to facilitate multiprocessing plugins, multiple workers requires at least that version of Arelle. Additionally, due to bugs in the cx_Freeze library which is used to produce the frozen Arelle builds (`exe` on windows, `dmg` on macOS, and `tgz` on Linux) multiple workers requires running Arelle and XULE from Python source. cx_Freeze is looking to resolve their multiprocessing bugs in the next minor release, so we may be able to remove this restriction in the future.

@campbellpryde @davidtauriello @marcward @derekgengenbacher-wf 