### PR TITLE
Handle wrapper IXDS document refs

### DIFF
--- a/plugin/xule/XuleProperties.py
+++ b/plugin/xule/XuleProperties.py
@@ -1891,8 +1891,11 @@ def property_entry_point_namespace(xule_context, object_value, *args):
             namespaces[item.uri] = item.targetNamespace
     elif dtstype == Type.INLINEXBRLDOCUMENTSET:
         for topitem in documentlist:
-            for item in topitem.referencesDocument:
-                namespaces[item.uri] = item.targetNamespace
+            if topitem.type == Type.SCHEMA:
+                namespaces[topitem.uri] = topitem.targetNamespace
+            else:
+                for item in topitem.referencesDocument:
+                    namespaces[item.uri] = item.targetNamespace
     else:
         namespaces[documentlist.uri] = documentlist.targetNamespace
     

--- a/plugin/xule/xule_grammar.py
+++ b/plugin/xule/xule_grammar.py
@@ -265,7 +265,7 @@ def get_grammar():
     qNameLocalName = Regex("([A-Za-z\xC0-\xD6\xD8-\xF6\xF8-\xFF\u0100-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF"
                            "\uF900-\uFDCF\uFDF0-\uFFFD_]"
                            "([A-Za-z0-9\xC0-\xD6\xD8-\xF6\xF8-\xFF\u0100-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF"
-                           "\uF900-\uFDCF\uFDF0-\uFFFD\u0300-\u036F\u203F-\u2040\xB7_-]|(\\\.))"
+                           "\uF900-\uFDCF\uFDF0-\uFFFD\u0300-\u036F\u203F-\u2040\xB7_-]|(\\\\.))"
                            "*)"
                   ).set_parse_action(lambda s, l, t: [t[0].replace('\\','')]) #parse action removes the escape backslash character
     prefix = qNameLocalName


### PR DESCRIPTION
The current IXDS Arelle plugin is setting the schema document refs on the wrapping IXDS model document instead of the iXBRL model document. This PR should allow XULE to work with both the current Arelle code that has the issue and future versions of Arelle once the issue has been resolved.

Can be tested with the files provided over email:
```bash
python arelleCmdLine.py --plugin "xule | transforms/SEC | inlineXbrlDocumentSet" -f 0000046619-22-000066-xbrl.zip --xule-compile ep.xule --xule-rule-set ep.zip --xule-debug --xule-crash --xule-run
```

Also resolves the following warning in Python 3.12:
```bash
xule/xule_grammar.py:268: SyntaxWarning: invalid escape sequence '\.'
  "\uF900-\uFDCF\uFDF0-\uFFFD\u0300-\u036F\u203F-\u2040\xB7_-]|(\\\.))"
```

@campbellpryde @marcward @phillipengel 