### PR TITLE
Limit cache size.

### DIFF
--- a/plugin/xule/XuleCache.py
+++ b/plugin/xule/XuleCache.py
@@ -1,0 +1,56 @@
+from collections import OrderedDict
+from collections.abc import MutableMapping
+
+from .XuleValue import XuleValue, XuleValueSet
+
+class XuleCache(MutableMapping):
+    def __init__(self, max_size_bytes):
+        self.max_size_bytes = max_size_bytes
+        self.values = OrderedDict()
+        self.sizes = {}
+        self.size = 0
+
+    def __len__(self):
+        return len(self.values)
+
+    def __iter__(self):
+        return iter(self.values)
+
+    def __contains__(self, key):
+        return key in self.values
+
+    def __delitem__(self, key):
+        self.size -= self.sizes.pop(key)
+        del self.values[key]
+
+    def __getitem__(self, key):
+        self.values.move_to_end(key)
+        return self.values[key]
+
+    def __setitem__(self, key, value):
+        self.size -= self.sizes.get(key, 0)
+        self.values[key] = value
+        self.sizes[key] = size = self._size(key, value)
+        self.size += size
+        while self.size > self.max_size_bytes:
+            key, _ = self.values.popitem(last=False)
+            self.size -= self.sizes.pop(key)
+
+    def get(self, key, default=None):
+        return self.values.get(key, default)
+
+    @staticmethod
+    def _size(key, value):
+        # Assume 1 KB per XuleValue.
+        xule_value_size = 1000
+        default_size = 24
+        try:
+            key_size = sum(xule_value_size if isinstance(k, XuleValue) else default_size for k in key)
+        except:
+            key_size = default_size
+        if isinstance(value, XuleValueSet):
+            # Assume 200 B per XuleValueSet key.
+            value_size = (200 + xule_value_size) * len(value.values)
+        else:
+            value_size = default_size
+        return key_size + value_size

--- a/plugin/xule/XuleContext.py
+++ b/plugin/xule/XuleContext.py
@@ -25,6 +25,7 @@ limitations under the License.
 $Change: 23719 $
 DOCSKIP
 """
+from .XuleCache import XuleCache
 from .XuleRunTime import XuleProcessingError
 from .XuleValue import XuleValue, XuleValueSet
 from . import XuleUtility as xu
@@ -32,7 +33,7 @@ from arelle import FileSource
 from arelle import ModelManager
 from queue import Queue
 from multiprocessing import Queue as M_Queue, Manager, cpu_count
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 import datetime
 from time import sleep
 import copy
@@ -351,7 +352,7 @@ class XuleRuleContext(object):
     _VAR_TYPE_CONSTANT = 2
     _VAR_TYPE_ARG = 3
 
-    def __init__(self, global_context, rule_name=None, cat_file_num=None):
+    def __init__(self, global_context, rule_name=None, cat_file_num=None, cache_size_bytes=1_000_000_000):
         """Rule Context constructor
         
         :param global_context: The global context
@@ -377,7 +378,7 @@ class XuleRuleContext(object):
         self.trace = collections.deque()
         self.in_where_alignment = None
         self.build_table = False
-        self.local_cache = {}
+        self.local_cache = XuleCache(max_size_bytes=cache_size_bytes)
         self.look_for_alignment = False
         self.where_table_ids = None
         self.where_dependent_iterables = None

--- a/plugin/xule/XuleProcessor.py
+++ b/plugin/xule/XuleProcessor.py
@@ -96,7 +96,7 @@ def process_xule(rule_set, model_xbrl, cntlr, options, saved_taxonomies=None):
         fact_index_start = datetime.datetime.today()
 
     # Create the processing context to build the index
-    xule_context = XuleRuleContext(global_context)
+    xule_context = XuleRuleContext(global_context, cache_size_bytes=getattr(global_context.options, 'xule_cache_size_bytes', 1_000_000_000))
     # Build an index on the facts in the model.
     xmi.index_model(xule_context)
     # Clean up

--- a/plugin/xule/XuleValue.py
+++ b/plugin/xule/XuleValue.py
@@ -69,6 +69,9 @@ class XuleValueSet:
         
         if values is not None:
             self.append(values)
+
+    def __contains__(self, value):
+        return value in self.values
             
     def __iter__(self):
         for val in self.values:

--- a/plugin/xule/__init__.py
+++ b/plugin/xule/__init__.py
@@ -463,6 +463,12 @@ def xuleCmdOptions(parser):
                       dest="xule_run",
                       help=_("Indicates that the rules should be processed."))
     
+    parserGroup.add_option("--xule-cache-size-bytes",
+                        action="store",
+                        dest="xule_cache_size_bytes",
+                        default=1_000_000_000,
+                        type="int",
+                        help=_("The maximum size of the per-rule expression cache in bytes."))
     parserGroup.add_option("--xule-max-rule-iterations",
                         action="store",
                         dest="xule_max_rule_iterations",


### PR DESCRIPTION
And add `__contains__` to XuleValueSet.
This saved about 32 GB of memory and a few minutes running the FERC viewer on a large document.