### PR TITLE
Save reloadable constants to json file and reload from file

### DIFF
--- a/plugin/xule/XuleContext.py
+++ b/plugin/xule/XuleContext.py
@@ -479,7 +479,9 @@ class XuleRuleContext(object):
                                     return XuleValue(self, frozenset(values), 'set')
                                 else:
                                     return XuleValue(self, tuple(values), 'list')
-                with open(xule_args_file, "r") as fh:
+                from arelle import FileSource
+                file_source = FileSource.openFileSource(xule_args_file, self.global_context.cntlr)
+                with file_source.file(xule_args_file, binary=True)[0] as fh: 
                     const_objs = json.load(fh)
                     for name, obj in const_objs.items():
                         overrides[name] = reloadValue(obj)

--- a/plugin/xule/XuleContext.py
+++ b/plugin/xule/XuleContext.py
@@ -303,6 +303,10 @@ class XuleGlobalContext(object):
                 self.rules_model.log("INFO",
                                    "other-taxonomy", 
                                    "Load taxonomy time %s from '%s'" % (end - start, taxonomy_url))
+            elif getattr(self.model, "log", None) is not None:
+                self.model.log("DEBUG",
+                               "xule.otherTaxonomyLoadTime", 
+                               "Load taxonomy time %s from '%s'" % (end - start, taxonomy_url))
             else:
                 print("Taxonomy Loaded. Load time %s from '%s' " % (end - start, taxonomy_url))            
         

--- a/plugin/xule/XuleContext.py
+++ b/plugin/xule/XuleContext.py
@@ -30,6 +30,7 @@ from .XuleRunTime import XuleProcessingError
 from .XuleValue import XuleValue, XuleValueSet
 from . import XuleUtility as xu
 from arelle import FileSource
+from arelle import ModelValue
 from queue import Queue
 from multiprocessing import Queue as M_Queue, Manager, cpu_count
 from collections import defaultdict, OrderedDict
@@ -37,6 +38,7 @@ import datetime
 from time import sleep
 import copy
 import collections
+import json
 from math import floor
 from io import StringIO
 import csv
@@ -441,6 +443,46 @@ class XuleRuleContext(object):
                     else:
                         val = XuleValue(self, None, 'none')
                     overrides[name] = val
+            xule_args_file = getattr(self.global_context.options,'xule_args_file', None)
+            if xule_args_file:
+                def reloadValue(obj, elt_type=None):
+                    if obj is None:
+                        return XuleValue(self, None, 'none')
+                    elif isinstance(obj, str):
+                        if elt_type == 'qname':
+                            return XuleValue(self, ModelValue.qname(obj), 'qname')
+                        elif elt_type == 'decimal':
+                            return XuleValue(self, Decimal(obj), 'decimal')
+                        return XuleValue(self, obj, 'string')
+                    elif isinstance(obj, float):
+                        return XuleValue(self, obj, 'float')
+                    elif isinstance(obj, list):
+                        _type = obj[0]
+                        if _type == "decimal":
+                            return XuleValue(self, Decimal(obj), 'decimal')
+                        elif _type == "qname":
+                            return XuleValue(self, ModelValue.qname(obj), 'qname')
+                        elif _type == "network":
+                            return XuleValue(self, tuple(obj[1:-1]), 'network')
+                        else:
+                            collection_elt_type = _type.split()
+                            collection_type = collection_elt_type[0]
+                            if collection_type in ('set', 'list'):
+                                try:
+                                    elt_type = _type.split()[1]
+                                except IndexError:
+                                    elt_type = None
+                                values = []
+                                for elt in obj[1:]:
+                                    values.append( reloadValue(elt, elt_type) )
+                                if collection_type == "set":
+                                    return XuleValue(self, frozenset(values), 'set')
+                                else:
+                                    return XuleValue(self, tuple(values), 'list')
+                with open(xule_args_file, "r") as fh:
+                    const_objs = json.load(fh)
+                    for name, obj in const_objs.items():
+                        overrides[name] = reloadValue(obj)
             self._constant_overridess = overrides
 
         return self._constant_overridess

--- a/plugin/xule/XuleContext.py
+++ b/plugin/xule/XuleContext.py
@@ -112,8 +112,11 @@ class XuleMessageQueue():
         ''' Logging statements for any text '''
         self.print(msg)
         
-    def print(self, msg):
-        print(msg)
+    def print(self, msg, codes=None):
+        if self._model is not None:
+            self._model.log("DEBUG", codes, msg)
+        else:
+            print(msg)
 
     def file(self, msg):
         pass

--- a/plugin/xule/XuleContext.py
+++ b/plugin/xule/XuleContext.py
@@ -466,6 +466,9 @@ class XuleRuleContext(object):
                 return XuleValue(self, ModelValue.qname(obj), 'qname')
             elif _type == "network":
                 return XuleValue(self, tuple(obj[1:-1]), 'network')
+            elif _type == "reference":
+                # this is not usable, value is ModelReference which would require a PrototypeDtsObject.py PrototypeObject to be implemented
+                return XuleValue(self, tuple(obj[1:-1]), 'reference')
             else:
                 collection_elt_type = _type.split()
                 collection_type = collection_elt_type[0]

--- a/plugin/xule/XuleContext.py
+++ b/plugin/xule/XuleContext.py
@@ -458,6 +458,8 @@ class XuleRuleContext(object):
             return XuleValue(self, obj, 'string')
         elif isinstance(obj, float):
             return XuleValue(self, obj, 'float')
+        elif isinstance(obj, int):
+            return XuleValue(self, obj, 'int')
         elif isinstance(obj, list):
             _type = obj[0]
             if _type == "decimal":
@@ -469,6 +471,11 @@ class XuleRuleContext(object):
             elif _type == "reference":
                 # this is not usable, value is ModelReference which would require a PrototypeDtsObject.py PrototypeObject to be implemented
                 return XuleValue(self, tuple(obj[1:-1]), 'reference')
+            elif _type == 'dictionary':
+                values = []
+                for item in obj[1:]:
+                    values.append( tuple(self.reload_value(elt, None) for elt in item) )
+                return XuleValue(self, tuple(values), 'dictionary')
             else:
                 collection_elt_type = _type.split()
                 collection_type = collection_elt_type[0]

--- a/plugin/xule/XuleContext.py
+++ b/plugin/xule/XuleContext.py
@@ -462,10 +462,10 @@ class XuleRuleContext(object):
             return XuleValue(self, obj, 'int')
         elif isinstance(obj, list):
             _type = obj[0]
-            if _type == "decimal":
-                return XuleValue(self, Decimal(obj), 'decimal')
-            elif _type == "qname":
-                return XuleValue(self, ModelValue.qname(obj), 'qname')
+            if _type == "decimal" and len(obj) == 2:
+                return XuleValue(self, Decimal(obj[1]), 'decimal')
+            elif _type == "qname" and len(obj) == 2:
+                return XuleValue(self, ModelValue.qname(obj[1]), 'qname')
             elif _type == "network":
                 return XuleValue(self, tuple(obj[1:-1]), 'network')
             elif _type == "reference":

--- a/plugin/xule/XuleProcessor.py
+++ b/plugin/xule/XuleProcessor.py
@@ -4975,6 +4975,9 @@ def convert_value_to_qname(value, model, xule_context):
         return return_values
     elif value.type in ('unbound', 'none'):
         return {None}
+    # HF addition for testing rule 0118, not sure why set of one qname is showing up here
+    elif value.type in ('list','set') and len(value.value) == 1 and next(iter(value.value)).type == "qname":
+        return {next(iter(value.value)).value,}
     else:
         raise XuleProcessingError(
             _("The value for a line item or dimension must be a qname or concept, found '%s'." % value.type),

--- a/plugin/xule/XuleProcessor.py
+++ b/plugin/xule/XuleProcessor.py
@@ -4978,6 +4978,8 @@ def convert_value_to_qname(value, model, xule_context):
     # HF addition for testing rule 0118, not sure why set of one qname is showing up here
     elif value.type in ('list','set') and len(value.value) == 1 and next(iter(value.value)).type == "qname":
         return {next(iter(value.value)).value,}
+    elif value.type in ('list','set') and len(value.value) == 0:
+        return {None}
     else:
         raise XuleProcessingError(
             _("The value for a line item or dimension must be a qname or concept, found '%s'." % value.type),

--- a/plugin/xule/XuleProcessor.py
+++ b/plugin/xule/XuleProcessor.py
@@ -122,7 +122,12 @@ def process_xule(rule_set, model_xbrl, cntlr, options, saved_taxonomies=None, is
     if getattr(global_context.options, "xule_args_file", False):
         constant_start = datetime.datetime.today()
         process_reloadable_constants(global_context)
-        global_context.message_queue.print("Time to calculated non instance constants: %s" % (datetime.datetime.today() - constant_start))
+        if getattr(global_context.model, "log", None) is not None:
+            global_context.model.log("DEBUG",
+                                     "xule.loadConstants", 
+                                     "Time to calculated non instance constants: %s" % (datetime.datetime.today() - constant_start))
+        else:
+            global_context.message_queue.print("Time to calculated non instance constants: %s" % (datetime.datetime.today() - constant_start))
 
     # Determine if constants should be outputed
     if getattr(global_context.options, "xule_output_constants", None) is not None:
@@ -1588,7 +1593,12 @@ def process_reloadable_constants(global_context):
 
     This function will calculate constants that do not depend directly on the instance.
     """
-    global_context.message_queue.logging("Reloading saved non-instance constants")
+    if getattr(global_context.model, "log", None) is not None:
+        global_context.model.log("DEBUG",
+                                 "xule.loadConstants", 
+                                 "Reloading saved non-instance constants")
+    else:
+        global_context.message_queue.logging("Reloading saved non-instance constants")
     from arelle import FileSource
     xule_args_file = getattr(global_context.options,'xule_args_file', None)
     file_source = FileSource.openFileSource(xule_args_file, global_context.cntlr)

--- a/plugin/xule/XuleProcessor.py
+++ b/plugin/xule/XuleProcessor.py
@@ -161,7 +161,7 @@ def output_constant(global_context, cntlr):
     cntlr.logger.removeHandler(cntlr.logHandler)
     cntlr.logger.addHandler(new_log_handler)
 
-    save_to_file = getattr(global_context.options, "xule_output_constants_file")
+    save_to_file = getattr(global_context.options, "xule_output_constants_file", None)
     const_objs = {} # for saving to a file
 
     for constant_name_raw in getattr(global_context.options, "xule_output_constants").split(','):
@@ -1600,8 +1600,8 @@ def process_reloadable_constants(global_context):
                 const_context = XuleRuleContext(global_context, constant_name, cat_constant['file'])
                 const_info = const_context.find_var(constant_name, cat_constant['node_id'])
                 if not const_info['calculated']:
-                    const_info['value'] = const_context.reload_value(obj)
-                    calc_constant(const_info, const_context)
+                    const_info['value'] = XuleValueSet(const_context.reload_value(obj))
+                    const_info['calculated'] = True
                 # Clean up
                 del const_context
             except KeyError:

--- a/plugin/xule/XuleProcessor.py
+++ b/plugin/xule/XuleProcessor.py
@@ -155,6 +155,9 @@ def output_constant(global_context, cntlr):
     cntlr.logger.removeHandler(cntlr.logHandler)
     cntlr.logger.addHandler(new_log_handler)
 
+    save_to_file = getattr(global_context.options, "xule_output_constants_file")
+    const_objs = {} # for saving to a file
+
     for constant_name_raw in getattr(global_context.options, "xule_output_constants").split(','):
         constant_name = constant_name_raw.strip()
         if constant_name != '':
@@ -164,7 +167,14 @@ def output_constant(global_context, cntlr):
             else:
                 for alignment, values in const_info['value'].values.items():
                     for val in values:
-                        cntlr.addToLog(val.format_value(), constant_name, messageArgs={'alignment': alignment, 'name': constant_name})
+                        if save_to_file:
+                            const_objs[constant_name] = val.reloadable_value
+                        else:
+                            cntlr.addToLog(val.format_value(), constant_name, messageArgs={'alignment': alignment, 'name': constant_name})
+
+    if save_to_file:
+        with open(save_to_file, "w") as fh:
+            json.dump(const_objs, fh)
 
     cntlr.logger.addHandler(save_log_handler)
 

--- a/plugin/xule/XuleProcessor.py
+++ b/plugin/xule/XuleProcessor.py
@@ -168,7 +168,7 @@ def output_constant(global_context, cntlr):
                 for alignment, values in const_info['value'].values.items():
                     for val in values:
                         if save_to_file:
-                            const_objs[constant_name] = val.reloadable_value
+                            const_objs[constant_name] = val.reloadable_value(constant_name)
                         else:
                             cntlr.addToLog(val.format_value(), constant_name, messageArgs={'alignment': alignment, 'name': constant_name})
 

--- a/plugin/xule/XuleUtility.py
+++ b/plugin/xule/XuleUtility.py
@@ -470,6 +470,9 @@ def get_model_manager_for_import(cntlr):
     if import_model_manager is None:
         import_model_manager = ModelManager.initialize(cntlr)
         import_model_manager.loadCustomTransforms()
+        # copy any custom integration mappings from cntlr's modelManager.disclosureSystem
+        import_model_manager.mappedFiles = cntlr.modelManager.disclosureSystem.mappedFiles.copy()
+        import_model_manager.mappedPaths = cntlr.modelManager.disclosureSystem.mappedPaths.copy()
         #import_model_manager.customTransforms = cntlr.modelManager.customTransforms
         XuleVars.set(cntlr, 'importModelManager', import_model_manager)
 

--- a/plugin/xule/XuleValue.py
+++ b/plugin/xule/XuleValue.py
@@ -373,6 +373,8 @@ class XuleValue:
         cached_value = xule_context.global_context.ancestry_cache.get(model_type, {}).get(find)
         if cached_value is not None:
             return cached_value
+        elif model_type is None:
+            return False # HF: modelType can be None for incomplete and unused concepts
         elif model_type.qname.clarkNotation == find.value:
             xule_context.global_context.ancestry_cache[model_type][find] = True
             return True

--- a/plugin/xule/XuleValue.py
+++ b/plugin/xule/XuleValue.py
@@ -632,6 +632,8 @@ class XuleValue:
             return ['decimal', str(self.value)]
         elif self.type in ('string', 'int', 'float', 'none'):
             return self.value
+        elif self.type == "reference": # [reference, arcrole, [qname, str], [qname, str], ...]
+            return ['reference', self.value.role] + [[part.qname.clarkNotation, part.textValue] for part in self.value]
         else:
             print(f"Constant {name}: type is not reloadable: {self.type}")
 

--- a/plugin/xule/XuleValue.py
+++ b/plugin/xule/XuleValue.py
@@ -609,6 +609,33 @@ class XuleValue:
         else:
             return num
 
+    @property
+    # reloadable value is a string or int or json array with type first and then value(s)
+    # types set, list and dict have entries following type.  Dict has [key, value]
+    def reloadable_value(self):
+        if self.type in ('set', 'list'):
+            types = set(x.type for x in self.value)
+            if len(types) == 1 and 'qname' in types:
+                return [f"{self.type} {types.pop()}"] + [x.value.clarkNotation for x in self.value]
+            elif len(types) == 1 and 'decimal' in types:
+                return [f"{self.type} {types.pop()}"] + [str(x.value) for x in self.value]
+            else:
+                return [self.type] + [x.reloadable_value for x in self.value]
+        elif self.type == 'list':
+            return ['list'] + [x.reloadable_value for x in self.value]
+        elif self.type == 'dictionary':
+            return ['dictionary'] + [[n.reloadable_value, v.reloadable_value] for n, v in self.value]
+        elif self.type == 'network':
+            return ['network'] + [str(x) for x in self.value[0]] + [len(self.value[1].modelRelationships)]
+        elif self.type == 'qname':
+            return ['qname', self.value.clarkNotation]
+        elif self.type == 'decimal':
+            return ['decimal', str(self.value)]
+        elif self.type in ('string', 'int', 'float', 'none'):
+            return self.value
+        else:
+            print(f"reloadable_value: type not reloadable: {self.type}")
+
 class XulePeriodComp:
     '''
     This class is used to compare periods.

--- a/plugin/xule/XuleValue.py
+++ b/plugin/xule/XuleValue.py
@@ -609,10 +609,9 @@ class XuleValue:
         else:
             return num
 
-    @property
     # reloadable value is a string or int or json array with type first and then value(s)
     # types set, list and dict have entries following type.  Dict has [key, value]
-    def reloadable_value(self):
+    def reloadable_value(self, name):
         if self.type in ('set', 'list'):
             types = set(x.type for x in self.value)
             if len(types) == 1 and 'qname' in types:
@@ -620,11 +619,11 @@ class XuleValue:
             elif len(types) == 1 and 'decimal' in types:
                 return [f"{self.type} {types.pop()}"] + [str(x.value) for x in self.value]
             else:
-                return [self.type] + [x.reloadable_value for x in self.value]
+                return [self.type] + [x.reloadable_value(name) for x in self.value]
         elif self.type == 'list':
-            return ['list'] + [x.reloadable_value for x in self.value]
+            return ['list'] + [x.reloadable_value(name) for x in self.value]
         elif self.type == 'dictionary':
-            return ['dictionary'] + [[n.reloadable_value, v.reloadable_value] for n, v in self.value]
+            return ['dictionary'] + [[n.reloadable_value(name), v.reloadable_value(name)] for n, v in self.value]
         elif self.type == 'network':
             return ['network'] + [str(x) for x in self.value[0]] + [len(self.value[1].modelRelationships)]
         elif self.type == 'qname':
@@ -634,7 +633,7 @@ class XuleValue:
         elif self.type in ('string', 'int', 'float', 'none'):
             return self.value
         else:
-            print(f"reloadable_value: type not reloadable: {self.type}")
+            print(f"Constant {name}: type is not reloadable: {self.type}")
 
 class XulePeriodComp:
     '''

--- a/plugin/xule/__init__.py
+++ b/plugin/xule/__init__.py
@@ -469,6 +469,11 @@ def xuleCmdOptions(parser):
                           dest="xule_arg",
                           help=_("Creates a constant. In the form of 'name=value'"))
 
+    parserGroup.add_option("--xule-args-file",
+                          action="store",
+                          dest="xule_args_file",
+                          help=_("Loads constants from a json file prepared by --xule-output-constants-file"))
+
     parserGroup.add_option("--xule-add-packages",
                            action="store",
                            dest="xule_add_packages",
@@ -625,6 +630,11 @@ def xuleCmdOptions(parser):
                            dest="xule_output_constants",
                            help=_("Comma separated list of constant names to output."))
     
+    parserGroup.add_option("--xule-output-constants-file",
+                           action="store",
+                           dest="xule_output_constants_file",
+                           help=_("File path to contain reloadable output constants, or write to log if absent."))
+
     parserGroup.add_option("--xule-exclude-nils",
                         action="store_true",
                         dest="xule_exclude_nils",

--- a/plugin/xule/__init__.py
+++ b/plugin/xule/__init__.py
@@ -1030,9 +1030,17 @@ def xuleValidate(val, extra_options=None):
     if extra_options:
         for n, v in extra_options.items():
             setattr(options, n, v)
+            if n == "block_Validate.Finally" and v:
+                setattr(val, "block_Validate.Finally", True)
 
     for xule_validator in _xule_validators:
-        if 'validate_flag' in xule_validator:
+        if getattr(val, "block_Validate.Finally", False):
+            # running under extraOptions control
+            if extra_options is None: # Validate.Finally which is blocked
+                return
+            elif len(val.modelXbrl.facts) > 0 and len(val.modelXbrl.qnameConcepts) > 0:
+                runXule(_cntlr, options, val.modelXbrl, xule_validator['map_name'], is_validator=True)
+        elif 'validate_flag' in xule_validator:
             # This is run in the GUI. The 'validate_flag' is only in the xule_validator when invoked from the GUI
             if xule_validator['validate_flag'].get():
                 # Only run if the validate_flag variable is ture (checked off in the validate menu)

--- a/plugin/xule/__init__.py
+++ b/plugin/xule/__init__.py
@@ -974,7 +974,7 @@ def runXule(cntlr, options, modelXbrl, rule_set_map=_xule_rule_set_map_name, is_
                     # check if there are any rules that need a model
                     for rule in rule_set.catalog['rules'].values():
                         if rule['dependencies']['instance'] == True and rule['dependencies']['rules-taxonomy'] != False:
-                            raise xr.XuleRuleSetError('Need instance to process rules')
+                            raise xr.XuleRuleSetError(f'Need instance to process rule {rule["full_name"]}')
                         
                 global _saved_taxonomies        
                 used_taxonomies = process_xule(rule_set,

--- a/plugin/xule/__init__.py
+++ b/plugin/xule/__init__.py
@@ -926,7 +926,7 @@ def xuleCmdUtilityRun(cntlr, options, **kwargs):
         xuleRegisterValidators('Xule', _xule_rule_set_map_name)
     
 def xuleCmdXbrlLoaded(cntlr, options, modelXbrl, *args, **kwargs):
-    if getattr(options, "xule_run", None) or getattr(options, "xule_output_constants") is not None:
+    if getattr(options, "xule_run", None) or getattr(options, "xule_output_constants", None) is not None:
         runXule(cntlr, options, modelXbrl)
 
 def xuleCompile(xule_file_names, ruleset_file_name, compile_type, max_recurse_depth=None, xule_compile_workers=1):

--- a/plugin/xule/__init__.py
+++ b/plugin/xule/__init__.py
@@ -1018,7 +1018,7 @@ def callXuleProcessor(cntlr, modelXbrl, rule_set_location, options):
         # output the message to the log and NOT raise an exception
         cntlr.addToLog(err.args[0] if len(err.args)>0 else 'Unknown rule compatibility error', 'xule', level=logging.ERROR)
 
-def xuleValidate(val):
+def xuleValidate(val, extra_options=None):
     global _cntlr
     global _xule_validators
 
@@ -1027,6 +1027,9 @@ def xuleValidate(val):
     options = xu.XuleVars.get(_cntlr, 'options')
     if options is None:
         options = EmptyOptions()
+    if extra_options:
+        for n, v in extra_options.items():
+            setattr(options, n, v)
 
     for xule_validator in _xule_validators:
         if 'validate_flag' in xule_validator:

--- a/plugin/xule/__init__.py
+++ b/plugin/xule/__init__.py
@@ -1038,6 +1038,8 @@ def xuleValidate(val, extra_options=None):
             # running under extraOptions control
             if extra_options is None: # Validate.Finally which is blocked
                 return
+            if extra_options.get("block_runXule", False): # runXule is blocked
+                return
             elif len(val.modelXbrl.facts) > 0 and len(val.modelXbrl.qnameConcepts) > 0:
                 runXule(_cntlr, options, val.modelXbrl, xule_validator['map_name'], is_validator=True)
         elif 'validate_flag' in xule_validator:

--- a/plugin/xule/__init__.py
+++ b/plugin/xule/__init__.py
@@ -1059,7 +1059,7 @@ def xuleValidate(val, extra_options=None):
             if not getattr(options, "xule_run", False) and len(val.modelXbrl.facts) > 0 and len(val.modelXbrl.qnameConcepts) > 0:
                 runXule(_cntlr, options, val.modelXbrl, xule_validator['map_name'], is_validator=True)
 
-    if getattr(_cntlr, 'hasWebServer', False) and not getattr(_cntlr, 'hasGui', False):
+    if getattr(_cntlr, 'hasWebServer', False) and not getattr(_cntlr, 'hasGui', False) and not getattr(options, "block_deregister", False):
         # When arelle is running as a webserver, it will register the xule_validators on each request to the web server. 
         # The _xule_validators is emptied. On the next request, the xule_validators for that request will be re-register.
         _xule_validators = []


### PR DESCRIPTION
### Add capability to save reloadable constants to json file and to reload from file.

Planned for use by EDGAR 25.1 which will preview to public Feb 17th.

Augments capability to trace constants in log file.

Arguments to save:
--xule-output-constants "FOO,BAR,..." --xule-output-constants-file {path-to-dest-file}.json

Arguments to reload:
 --xule-args-file {path-to-saved-file}.json

File format:
  * Dict whose keys are the constant names, and whose values are, recursively:
       * string:  "just a json string"
       * float:  123.45 (json number representation)
       * None:  null (json null representation)
       * single qname: ["qname", "{namespaceURI}localName"]
       * single decimal: ["decimal", "string representation of decimal number"]
       * collection:   [("set"|"list|network", contents]
       * dictionary:  { key: recursive values, ... }
  * Collections with non-complex members all the same, e.g. qname or decimal:
       * set of only qnames: ["set qname", "{ns1}ln1", "{ns2}ln2", ...]