### PR TITLE
Option for run only pattern

### DIFF
--- a/plugin/xule/XuleProcessor.py
+++ b/plugin/xule/XuleProcessor.py
@@ -50,6 +50,7 @@ from . import XuleProperties
 import os
 from openpyxl import load_workbook, Workbook
 import json
+import regex as re
 
 def process_xule(rule_set, model_xbrl, cntlr, options, saved_taxonomies=None, is_validator=False):
     """Run xule rules against a filing.
@@ -208,6 +209,8 @@ def evaluate_rule_set(global_context):
     # Create a list of run only rules. This is the opposite of skip_rules. If run_only is not NOne than only those rules will be processed.
     run_only_rules = getattr(global_context.options, "xule_run_only", None).split(",") if getattr(
         global_context.options, "xule_run_only", None) is not None else None
+    run_only_rule_pattern = re.compile(getattr(global_context.options, "xule_run_only_pattern")) if getattr(
+        global_context.options, "xule_run_only_pattern", None) is not None else None
 
     # use the term "cat" for catalog information. Read through the list of rules in the catalog.
     for file_num, cat_rules in global_context.catalog['rules_by_file'].items():
@@ -219,6 +222,8 @@ def evaluate_rule_set(global_context):
                 continue
 
             if not (run_only_rules is None or rule_name in run_only_rules):
+                continue
+            if not (run_only_rule_pattern is None or run_only_rule_pattern.match(rule_name)):
                 continue
 
             # get the AST for the rule from the ruleset

--- a/plugin/xule/XuleProperties.py
+++ b/plugin/xule/XuleProperties.py
@@ -2027,6 +2027,8 @@ def property_entry_point_namespace(xule_context, object_value, *args):
         return xv.XuleValue(xule_context, namespace, 'uri')
 
 def get_concept(dts, concept_qname):
+    if dts is None:
+        return None
     concept = dts.qnameConcepts.get(concept_qname)
     if concept is None:
         return None

--- a/plugin/xule/__init__.py
+++ b/plugin/xule/__init__.py
@@ -615,6 +615,11 @@ def xuleCmdOptions(parser):
                         dest="xule_run_only",
                         help=_("List of rules to run"))    
     
+    parserGroup.add_option("--xule-run-only-pattern",
+                        action="store",
+                        dest="xule_run_only_pattern",
+                        help=_("Regex of rules to run"))
+
     parserGroup.add_option("--xule-no-cache",
                         action="store_true",
                         dest="xule_no_cache",


### PR DESCRIPTION
The --xule-run-only feature is not generally usable because it requires a list of rules including their id, which in the case of DQCRT is thousands.

This pull request adds --xule-run-only-pattern which takes a regex which when matched by a rule runs it, so the match pattern can be just the beginning of the rule, omitting ID, or even a negative lookahead (e.g. don't-run).