### PR TITLE
Replace use of `PackageManager` with `Cntlr.packages`

### DIFF
--- a/plugin/xule/XuleFunctions.py
+++ b/plugin/xule/XuleFunctions.py
@@ -25,7 +25,7 @@ DOCSKIP
 
 from aniso8601 import parse_duration
 from arelle.ModelValue import qname, QName
-from arelle import FileSource, PackageManager, FunctionIxt
+from arelle import FileSource, FunctionIxt
 import collections
 from collections.abc import Iterable
 from contextlib import contextmanager
@@ -692,7 +692,7 @@ def func_csv_data(xule_context, *args):
     result = list()
     result_shadow = list()
     
-    mapped_file_url = PackageManager.mappedUrl(file_url.value)
+    mapped_file_url = xule_context.global_context.cntlr.packages.map(file_url.value)
 
     # Using the FileSource object in arelle. This will open the file and handle taxonomy package mappings.
     file_source = FileSource.openFileSource(file_url.value, xule_context.global_context.cntlr)
@@ -859,7 +859,7 @@ def func_json_data(xule_context, *args):
     if file_url.type not in ('string', 'uri'):
         raise XuleProcessingError(_("The file url argument of the json-dta() function must be a string or uri, found '{}'.".format(file_url.value)), xule_context)
 
-    mapped_file_url = PackageManager.mappedUrl(file_url.value)
+    mapped_file_url = xule_context.global_context.cntlr.packages.map(file_url.value)
 
     # Using the FileSource object in arelle. This will open the file and handle taxonomy package mappings.
     file_source = FileSource.openFileSource(file_url.value, xule_context.global_context.cntlr)

--- a/plugin/xule/XuleRuleSet.py
+++ b/plugin/xule/XuleRuleSet.py
@@ -33,7 +33,6 @@ import os
 import pickle
 import tempfile
 import zipfile
-from arelle import PackageManager
 from pickle import UnpicklingError
 from . import XuleConstants as xc
 from . import XuleUtility as xu
@@ -176,7 +175,7 @@ class XuleRuleSet(object):
         :type file_name: str
         :return: The package information. This is the return from Arelle when activating the package
         """
-        package_info = PackageManager.addPackage(self._cntlr, file_name)
+        package_info = self._cntlr.packages.add(file_name)
         if package_info:
 #                     print("Activation of package {0} successful.".format(package_info.get("name")))    
             self._cntlr.addToLog(_("Activation of package {0} successful.").format(package_info.get("name")), 
@@ -203,7 +202,7 @@ class XuleRuleSet(object):
                 for package_file_name in zf.namelist():
                     if package_file_name.startswith('packages/'):
                         package_file = zf.extract(package_file_name, temp_dir.name)
-                        package_info = PackageManager.addPackage(self._cntlr, package_file)
+                        package_info = self._cntlr.packages.add(package_file)
                         results.append(package_info)
         finally:
             file_object.close()
@@ -549,4 +548,3 @@ class XuleRuleSet(object):
                 self.catalog.get('xule_compiled_version'), xu.version(), xu.get_rule_set_compatibility_version())
             )
 
-                


### PR DESCRIPTION
#### Description:
Refactor package management to align with the [upcoming deprecation](https://github.com/Arelle/Arelle/issues/2269) of the global `PackageManager` in Arelle. This update migrates logic to use the `PackageRegistry` instance provided by the `Cntlr` (accessible via `cntlr.packages`).

@campbellpryde
@davidtauriello