### PR TITLE
Replace use of `PluginManager` with `Cntlr.plugins`

### DIFF
--- a/plugin/FERC/render.py
+++ b/plugin/FERC/render.py
@@ -2,7 +2,6 @@
 Reivision number: $Change$
 '''
 from arelle import FileSource
-from arelle import PluginManager
 from arelle.CntlrWebMain import Options
 from arelle.ModelRelationshipSet import ModelRelationshipSet
 from arelle.ModelDocument import Type
@@ -27,9 +26,6 @@ import tempfile
 import uuid
 import zipfile
 
-# This will hold the xule plugin module
-_xule_plugin_info = None
-
 # xule namespace used in the template
 _XULE_NAMESPACE_MAP = {'xule': 'http://xbrl.us/xule/2.0/template', 
                        'xhtml': 'http://www.w3.org/1999/xhtml',
@@ -49,28 +45,21 @@ _ORIGINAL_FACT_ID_ATTRIBUTE = 'original_fact_id'
 class FERCRenderException(Exception):
     pass
 
-def getXulePlugin(cntlr):
-    """Find the Xule plugin
-    
-    This will locate the Xule plugin module.
-    """
-    global _xule_plugin_info
-    if _xule_plugin_info is None:
-        for _plugin_name, plugin_info in PluginManager.modulePluginInfos.items():
-            if plugin_info.get('moduleURL') == 'xule':
-                _xule_plugin_info = plugin_info
-                break
-        else:
-            cntlr.addToLog(_("Xule plugin is not loaded. Xule plugin is required to run DQC rules. This plugin should be automatically loaded."))
-    
-    return _xule_plugin_info
-
-def getXuleMethod(cntlr, method_name):
+def getXuleMethods(cntlr, method_name):
     """Get method from Xule
-    
+
     Get a method/function from the Xule plugin. This is how this validator calls functions in the Xule plugin.
     """
-    return getXulePlugin(cntlr).get(method_name)
+    hooks = list(cntlr.plugins.hooks(method_name))
+    if not hooks:
+        cntlr.addToLog(
+            _("Plugin with '%(name)s' is not loaded. "
+              "Xule plugin is required to run %(rules)s rules. "
+              "This plugin should be automatically loaded."),
+            name=method_name,
+            rules='DQC',
+        )
+    return hooks
 
 
 def process_template(cntlr, template_file_name, options):
@@ -1942,8 +1931,8 @@ def process_single_template(cntlr, options, template_catalog, template_set_file,
 
         # xule rule set name
         xule_rule_set_name = os.path.join(temp_dir, 'temp-ruleset.zip')
-        compile_method = getXuleMethod(cntlr, 'Xule.compile')
-        compile_method(xule_rule_file_name, xule_rule_set_name, 'pickle', getattr(options, "xule_max_recurse_depth"))
+        for compile_method in getXuleMethods(cntlr, 'Xule.compile'):
+            compile_method(xule_rule_file_name, xule_rule_set_name, 'pickle', getattr(options, "xule_max_recurse_depth"))
 
         template_catalog.append({'name': template_name,
                             'template': template_file_name,
@@ -2182,14 +2171,15 @@ def render_report(cntlr, options, modelXbrl, *args, **kwargs):
             cntlr.logger.addHandler(log_capture_handler)
 
             # Call the xule processor to run the rules
-            call_xule_method = getXuleMethod(cntlr, 'Xule.callXuleProcessor')
+            call_xule_methods = getXuleMethods(cntlr, 'Xule.callXuleProcessor')
             run_options = deepcopy(options)
             xule_args = getattr(run_options, 'xule_arg', []) or []
             xule_args += list(xule_date_args)
             setattr(run_options, 'xule_arg', xule_args)
-                # Get xule rule set
-            with ts.open(catalog_item['xule-rule-set']) as rule_set_file:
-                call_xule_method(cntlr, modelXbrl, io.BytesIO(rule_set_file.read()), run_options)
+            # Get xule rule set
+            for call_xule_method in call_xule_methods:
+                with ts.open(catalog_item['xule-rule-set']) as rule_set_file:
+                    call_xule_method(cntlr, modelXbrl, io.BytesIO(rule_set_file.read()), run_options)
             
             # Remove the handler from the logger. This will stop the capture of messages
             cntlr.logger.removeHandler(log_capture_handler)

--- a/plugin/Xince.py
+++ b/plugin/Xince.py
@@ -4,7 +4,6 @@ Reivision number: $Change: 23365 $
 
 from arelle import FileSource
 from arelle import ModelManager
-from arelle import PluginManager
 
 import base64
 import collections
@@ -21,9 +20,6 @@ import os
 import re
 import tempfile
 
-
-# This will hold the xule plugin module
-_xule_plugin_info = None
 
 _XBRLI_NAMESPACE = 'http://www.xbrl.org/2003/instance'
 _LINK_NAMESPACE = 'http://www.xbrl.org/2003/linkbase'
@@ -375,28 +371,21 @@ class IDGenerator:
 
         return cls._generators[(inst_name, prefix)]
 
-def getXulePlugin(cntlr):
-    """Find the Xule plugin
-    
-    This will locate the Xule plugin module.
-    """
-    global _xule_plugin_info
-    if _xule_plugin_info is None:
-        for _plugin_name, plugin_info in PluginManager.modulePluginInfos.items():
-            if plugin_info.get('moduleURL') == 'xule':
-                _xule_plugin_info = plugin_info
-                break
-        else:
-            cntlr.addToLog(_("Xule plugin is not loaded. Xule plugin is required to run DQC rules. This plugin should be automatically loaded."), "XinceError", level=logging.ERROR)
-    
-    return _xule_plugin_info
-
-def getXuleMethod(cntlr, method_name):
+def getXuleMethods(cntlr, method_name):
     """Get method from Xule
-    
+
     Get a method/function from the Xule plugin. This is how this validator calls functions in the Xule plugin.
     """
-    return getXulePlugin(cntlr).get(method_name)
+    hooks = list(cntlr.plugins.hooks(method_name))
+    if not hooks:
+        cntlr.addToLog(
+            _("Plugin with '%(name)s' is not loaded. "
+              "Xule plugin is required to run %(rules)s rules. "
+              "This plugin should be automatically loaded."),
+            name=method_name,
+            rules='DQC',
+        )
+    return hooks
 
 def cmdLineOptionExtender(parser, *args, **kwargs):
     
@@ -1628,7 +1617,7 @@ def run_xule(cntlr, options, modelXbrl):
     cntlr.logger.addHandler(log_capture_handler)
 
     # Call the xule processor to run the rules
-    call_xule_method = getXuleMethod(cntlr, 'Xule.callXuleProcessor')
+    call_xule_methods = getXuleMethods(cntlr, 'Xule.callXuleProcessor')
     run_options = copy.deepcopy(options)
             
     #xule_args = getattr(run_options, 'xule_arg', []) or []
@@ -1637,7 +1626,8 @@ def run_xule(cntlr, options, modelXbrl):
         # Get xule rule set
     # with ts.open(catalog_item['xule-rule-set']) as rule_set_file:
     setattr(run_options, 'logRefObjectProperties', False)
-    call_xule_method(cntlr, modelXbrl, options.xule_rule_set, run_options)
+    for call_xule_method in call_xule_methods:
+        call_xule_method(cntlr, modelXbrl, options.xule_rule_set, run_options)
     
     # Remove the handler from the logger. This will stop the capture of messages
     cntlr.logger.removeHandler(log_capture_handler)

--- a/plugin/serializer/__init__.py
+++ b/plugin/serializer/__init__.py
@@ -8,11 +8,10 @@ import zipfile
 
 from lxml import etree
 
-from arelle import FileSource, PackageManager, PluginManager
+from arelle import FileSource
 
 _CNTLR = None
 _OPTIONS = None
-_PLUGINS = {}
 _SXM = None
 _PACKAGE_FOLDER = None
 
@@ -90,6 +89,14 @@ _RESOURCE_LINKBASES = {'Label': {'extended_link': '{http://www.xbrl.org/2003/lin
                                      'arc': '{http://www.xbrl.org/2003/linkbase}referenceArc',  
                                      'resource': '{http://www.xbrl.org/2003/linkbase}reference',
                                      'arcrole': 'http://www.xbrl.org/2003/arcrole/concept-reference'}}
+
+_SXM_PLUGIN_NAME = 'SimpleXBRLModel'
+
+def getSxmModule(cntlr):
+    if _SXM_PLUGIN_NAME not in cntlr.plugins.get_plugins():
+        cntlr.addToLog(_("'{plugin_name}'' plugin is not loaded. '{plugin_name}' plugin is required. "
+                         "This plugin should be automatically loaded.".format(plugin_name=_SXM_PLUGIN_NAME)))
+    return next(cntlr.plugins.hooks('SXM.getModule'))()
 
 class SerializerException(Exception):
     pass
@@ -221,41 +228,6 @@ _GENERIC_NAMESPACES = {'http://xbrl.org/2008/generic': {'prefix': 'gen', 'locati
                        'http://xbrl.org/2008/reference': {'prefix': 'ref', 'location': 'http://www.xbrl.org/2008/generic-reference.xsd'}
 }
 
-# Utility to find another plugin
-def getSerizlierPlugins(cntlr):
-    '''Serializer plugins have a 'serializer.serialize' entry in the _PLUGIN dictionary.'''
-    serializer_plugins = []
-    for _x, plugin_info in PluginManager.modulePluginInfos.items():
-        if 'serializer.serialize' in plugin_info:
-            serializer_plugins.append(plugin_info)
-    
-    return serializer_plugins
-
-def getPlugin(cntlr, plugin_name):
-    """Find the  plugin
-    
-    This will locate the plugin module.
-    """
-    global _PLUGINS
-    if plugin_name not in _PLUGINS:
-        for _x, plugin_info in PluginManager.modulePluginInfos.items():
-            if plugin_info.get('moduleURL') == plugin_name:
-                _PLUGINS[plugin_name] = plugin_info
-                break
-        else:
-            cntlr.addToLog(_("'{plugin_name}'' plugin is not loaded. '{plugin_name}' plugin is required. "
-                             "This plugin should be automatically loaded.".format(plugin_name=plugin_name)))
-    
-    return _PLUGINS[plugin_name]
-
-def getPluginObject(cntlr, plugin_name, object_name):
-    """Get method from a plugin
-    
-    Get a method/function from a plugin.
-    """
-    return getPlugin(cntlr, plugin_name).get(object_name)
-
-
 def error(msg, code='Serializer'):
     _CNTLR.addToLog(msg, code, level=logging.ERROR)
     if not getattr(_OPTIONS, 'serializer_package_allow_errors', False):
@@ -359,7 +331,7 @@ def  cmdUtilityRun(cntlr, options, **kwargs):
 
     # Get the Simple XBRL Model Module.
     global _SXM
-    _SXM = getPluginObject(cntlr, 'SimpleXBRLModel', 'SXM.getModule')()
+    _SXM = getSxmModule(cntlr)
 
     parser = optparse.OptionParser()
 
@@ -415,8 +387,8 @@ def cmndLineXbrlRun(cntlr, options, model_xbrl, entryPoint, *args, **kwargs):
         return
     _PACKAGE_FOLDER = posixpath.splitext(posixpath.basename(options.serializer_package_name))[0]
 
-    for serializer in getSerizlierPlugins(cntlr):
-        dts = serializer['serializer.serialize'](model_xbrl, options, _SXM)
+    for hook in cntlr.plugins.hooks('serializer.serialize'):
+        dts = hook(model_xbrl, options, _SXM)
         package_name = None
         if dts.package_base_file_name is None:
             # Check if a name is supplied.
@@ -435,7 +407,7 @@ def init_SXM(cntlr):
 
     # Get the Simple XBRL Model Module.
     global _SXM
-    _SXM = getPluginObject(cntlr, 'SimpleXBRLModel', 'SXM.getModule')()
+    _SXM = getSxmModule(cntlr)
 
 def write(dts, package_name, cntlr):
 

--- a/plugin/serializer/__init__.py
+++ b/plugin/serializer/__init__.py
@@ -94,7 +94,7 @@ _SXM_PLUGIN_NAME = 'SimpleXBRLModel'
 
 def getSxmModule(cntlr):
     if _SXM_PLUGIN_NAME not in cntlr.plugins.get_plugins():
-        cntlr.addToLog(_("'{plugin_name}'' plugin is not loaded. '{plugin_name}' plugin is required. "
+        cntlr.addToLog(_("'{plugin_name}' plugin is not loaded. '{plugin_name}' plugin is required. "
                          "This plugin should be automatically loaded.".format(plugin_name=_SXM_PLUGIN_NAME)))
     return next(cntlr.plugins.hooks('SXM.getModule'))()
 

--- a/plugin/validate/DQC.py
+++ b/plugin/validate/DQC.py
@@ -24,7 +24,6 @@ $Change$
 DOCSKIP
 """
 import optparse
-from arelle import PluginManager
 
 """ Xule validator specific variables."""
 _short_name = 'DQC'
@@ -39,8 +38,6 @@ _rule_set_map_name = 'rulesetMap.json'
 _latest_map_name = 'https://github.com/DataQualityCommittee/dqc_us_rules/raw/master/rulesetMap.json' 
 
 """Do not change anything below this line."""
-_xule_plugin_info = None
-
 def cmdOptions(parser):
     """Extend command line options for xule validator
     
@@ -100,8 +97,8 @@ def cntrlrCmdLineUtilityRun(cntlr, options, **kwargs):
     This is invoked by the Arelle controler after Arelle is fully up but before a filing is loaded.
     """
     # Save options in xule
-    save_options_method = getXuleMethod(cntlr, 'Xule.CntrlCmdLine.Utility.Run.Init')
-    save_options_method(cntlr, options, **kwargs)
+    for save_options_method in getXuleMethods(cntlr, 'Xule.CntrlCmdLine.Utility.Run.Init'):
+        save_options_method(cntlr, options, **kwargs)
 
     parser = optparse.OptionParser()
     
@@ -122,80 +119,72 @@ def cntrlrCmdLineUtilityRun(cntlr, options, **kwargs):
     
     # Show validator version
     if getattr(options, '{}_version'.format(_short_name), False):
-        version_method = getXuleMethod(cntlr, 'Xule.ValidatorVersion')
-        version_method(cntlr, _short_name, _rule_set_map_name, _version_prefix, __file__)
+        for version_method in getXuleMethods(cntlr, 'Xule.ValidatorVersion'):
+            version_method(cntlr, _short_name, _rule_set_map_name, _version_prefix, __file__)
 
         #cntlr.addToLog("{} validator version: {}".format(_short_name,  _version_prefix + version_method(__file__)), _short_name)
         #cntlr.close()
     
     # Update the rule set map
     if getattr(options, "{}_update_rule_set_map".format(_short_name), False):
-        update_method = getXuleMethod(cntlr, 'Xule.RulesetMap.Update')
-        update_method(cntlr, getattr(options,"{}_update_rule_set_map".format(_short_name)), _rule_set_map_name)
+        for update_method in getXuleMethods(cntlr, 'Xule.RulesetMap.Update'):
+            update_method(cntlr, getattr(options,"{}_update_rule_set_map".format(_short_name)), _rule_set_map_name)
     
     # Replace the rule set map
     if getattr(options, "{}_replace_rule_set_map".format(_short_name), False):
-        update_method = getXuleMethod(cntlr, 'Xule.RulesetMap.Replace')
-        update_method(cntlr, getattr(options,"{}_replace_rule_set_map".format(_short_name)), _rule_set_map_name)
+        for update_method in getXuleMethods(cntlr, 'Xule.RulesetMap.Replace'):
+            update_method(cntlr, getattr(options,"{}_replace_rule_set_map".format(_short_name)), _rule_set_map_name)
     
     # Display the rule set map
     if getattr(options, "{}_display_rule_set_map".format(_short_name), False):
-        update_method = getXuleMethod(cntlr, 'Xule.RulesetMap.Display')
-        update_method(cntlr, _short_name, _rule_set_map_name)
+        for update_method in getXuleMethods(cntlr, 'Xule.RulesetMap.Display'):
+            update_method(cntlr, _short_name, _rule_set_map_name)
 
     # Update the rule set map with the latest
     if getattr(options, "{}_update_rule_set_map_latest".format(_short_name), False):
-        update_method = getXuleMethod(cntlr, 'Xule.RulesetMap.Update')
-        update_method(cntlr, _latest_map_name, _rule_set_map_name)
+        for update_method in getXuleMethods(cntlr, 'Xule.RulesetMap.Update'):
+            update_method(cntlr, _latest_map_name, _rule_set_map_name)
 
     # Replace the rule set map with the latest
     if getattr(options, "{}_replace_rule_set_map_latest".format(_short_name), False):
-        update_method = getXuleMethod(cntlr, 'Xule.RulesetMap.Replace')
-        update_method(cntlr, _latest_map_name, _rule_set_map_name)
+        for update_method in getXuleMethods(cntlr, 'Xule.RulesetMap.Replace'):
+            update_method(cntlr, _latest_map_name, _rule_set_map_name)
 
     # Register the xule validator
-    registerMethod = getXuleMethod(cntlr, 'Xule.RegisterValidator')
-    registerMethod(_short_name, _rule_set_map_name)
-    
-def getXulePlugin(cntlr):
-    """Find the Xule plugin
-    
-    This will locate the Xule plugin module.
-    """
-    global _xule_plugin_info
-    if _xule_plugin_info is None:
-        for plugin_name, plugin_info in PluginManager.modulePluginInfos.items():
-            if plugin_info.get('moduleURL') == 'xule':
-                _xule_plugin_info = plugin_info
-                break
-        else:
-            cntlr.addToLog(_("Xule plugin is not loaded. Xule plugin is required to run DQC rules. This plugin should be automatically loaded."))
-    
-    return _xule_plugin_info
+    for registerMethod in getXuleMethods(cntlr, 'Xule.RegisterValidator'):
+        registerMethod(_short_name, _rule_set_map_name)
 
-def getXuleMethod(cntlr, class_name):
+def getXuleMethods(cntlr, class_name):
     """Get method from Xule
-    
+
     Get a method/function from the Xule plugin. This is how this validator calls functions in the Xule plugin.
     """
-    return getXulePlugin(cntlr).get(class_name)
+    hooks = list(cntlr.plugins.hooks(class_name))
+    if not hooks:
+        cntlr.addToLog(
+            _("Plugin with '%(name)s' is not loaded. "
+              "Xule plugin is required to run %(rules)s rules. "
+              "This plugin should be automatically loaded."),
+            name=class_name,
+            rules='DQC',
+        )
+    return hooks
 
 def menuTools(cntlr, menu):
     """Add validator menu the Tools menu in the Arelle GUI
     
     This is invoked by the Arelle controller
     """
-    menu_method = getXuleMethod(cntlr, 'Xule.AddMenuTools')
-    version_method = getXuleMethod(cntlr, 'Xule.ValidatorVersion')
-    menu_method(cntlr, menu, _short_name, _version_prefix, __file__, _rule_set_map_name, _latest_map_name)
+    for menu_method in getXuleMethods(cntlr, 'Xule.AddMenuTools'):
+        menu_method(cntlr, menu, _short_name, _version_prefix, __file__, _rule_set_map_name, _latest_map_name)
 
 def validateMenuTools(cntlr, validateMenu, *args, **kwargs):
     """Add validator checkbutton to the Arelle Validate menu (under Tools).
     
     This is invoked by the Arelle controller.
     """
-    menu_method = getXuleMethod(cntlr, 'Xule.AddValidationMenuTools')
-    menu_method(cntlr, validateMenu, _short_name, _rule_set_map_name)
+    for menu_method in getXuleMethods(cntlr, 'Xule.AddValidationMenuTools'):
+        menu_method(cntlr, validateMenu, _short_name, _rule_set_map_name)
     
 __pluginInfo__ = {
     'name': _name,

--- a/plugin/validate/eforms.py
+++ b/plugin/validate/eforms.py
@@ -24,7 +24,6 @@ $Change: 22782 $
 DOCSKIP
 """
 import optparse
-from arelle import PluginManager
 
 """ Xule validator specific variables."""
 _short_name = 'eForms'
@@ -39,8 +38,6 @@ _rule_set_map_name = 'fercRulesetMap.json'
 _latest_map_name = 'https://github.com/xbrlus/ferc-validation-rulesets/raw/main/fercRulesetMap.json' 
 
 """Do not change anything below this line."""
-_xule_plugin_info = None
-
 def cmdOptions(parser):
     """Extend command line options for xule validator
     
@@ -100,8 +97,8 @@ def cntrlrCmdLineUtilityRun(cntlr, options, **kwargs):
     This is invoked by the Arelle controler after Arelle is fully up but before a filing is loaded.
     """
     # Save options in xule
-    save_options_method = getXuleMethod(cntlr, 'Xule.CntrlCmdLine.Utility.Run.Init')
-    save_options_method(cntlr, options, **kwargs)
+    for save_options_method in getXuleMethods(cntlr, 'Xule.CntrlCmdLine.Utility.Run.Init'):
+        save_options_method(cntlr, options, **kwargs)
 
     parser = optparse.OptionParser()
     
@@ -122,80 +119,72 @@ def cntrlrCmdLineUtilityRun(cntlr, options, **kwargs):
     
     # Show validator version
     if getattr(options, '{}_version'.format(_short_name), False):
-        version_method = getXuleMethod(cntlr, 'Xule.ValidatorVersion')
-        version_method(cntlr, _short_name, _rule_set_map_name, _version_prefix, __file__)
+        for version_method in getXuleMethods(cntlr, 'Xule.ValidatorVersion'):
+            version_method(cntlr, _short_name, _rule_set_map_name, _version_prefix, __file__)
 
         #cntlr.addToLog("{} validator version: {}".format(_short_name,  _version_prefix + version_method(__file__)), _short_name)
         #cntlr.close()
     
     # Update the rule set map
     if getattr(options, "{}_update_rule_set_map".format(_short_name), False):
-        update_method = getXuleMethod(cntlr, 'Xule.RulesetMap.Update')
-        update_method(cntlr, getattr(options,"{}_update_rule_set_map".format(_short_name)), _rule_set_map_name)
+        for update_method in getXuleMethods(cntlr, 'Xule.RulesetMap.Update'):
+            update_method(cntlr, getattr(options,"{}_update_rule_set_map".format(_short_name)), _rule_set_map_name)
     
     # Replace the rule set map
     if getattr(options, "{}_replace_rule_set_map".format(_short_name), False):
-        update_method = getXuleMethod(cntlr, 'Xule.RulesetMap.Replace')
-        update_method(cntlr, getattr(options,"{}_replace_rule_set_map".format(_short_name)), _rule_set_map_name)
+        for update_method in getXuleMethods(cntlr, 'Xule.RulesetMap.Replace'):
+            update_method(cntlr, getattr(options,"{}_replace_rule_set_map".format(_short_name)), _rule_set_map_name)
     
     # Display the rule set map
     if getattr(options, "{}_display_rule_set_map".format(_short_name), False):
-        update_method = getXuleMethod(cntlr, 'Xule.RulesetMap.Display')
-        update_method(cntlr, _short_name, _rule_set_map_name)
+        for update_method in getXuleMethods(cntlr, 'Xule.RulesetMap.Display'):
+            update_method(cntlr, _short_name, _rule_set_map_name)
 
     # Update the rule set map with the latest
     if getattr(options, "{}_update_rule_set_map_latest".format(_short_name), False):
-        update_method = getXuleMethod(cntlr, 'Xule.RulesetMap.Update')
-        update_method(cntlr, _latest_map_name, _rule_set_map_name)
+        for update_method in getXuleMethods(cntlr, 'Xule.RulesetMap.Update'):
+            update_method(cntlr, _latest_map_name, _rule_set_map_name)
 
     # Replace the rule set map with the latest
     if getattr(options, "{}_replace_rule_set_map_latest".format(_short_name), False):
-        update_method = getXuleMethod(cntlr, 'Xule.RulesetMap.Replace')
-        update_method(cntlr, _latest_map_name, _rule_set_map_name)
+        for update_method in getXuleMethods(cntlr, 'Xule.RulesetMap.Replace'):
+            update_method(cntlr, _latest_map_name, _rule_set_map_name)
 
     # Register the xule validator
-    registerMethod = getXuleMethod(cntlr, 'Xule.RegisterValidator')
-    registerMethod(_short_name, _rule_set_map_name)
-    
-def getXulePlugin(cntlr):
-    """Find the Xule plugin
-    
-    This will locate the Xule plugin module.
-    """
-    global _xule_plugin_info
-    if _xule_plugin_info is None:
-        for plugin_name, plugin_info in PluginManager.modulePluginInfos.items():
-            if plugin_info.get('moduleURL') == 'xule':
-                _xule_plugin_info = plugin_info
-                break
-        else:
-            cntlr.addToLog(_("Xule plugin is not loaded. Xule plugin is required to run FERC rules. This plugin should be automatically loaded."))
-    
-    return _xule_plugin_info
+    for registerMethod in getXuleMethods(cntlr, 'Xule.RegisterValidator'):
+        registerMethod(_short_name, _rule_set_map_name)
 
-def getXuleMethod(cntlr, class_name):
+def getXuleMethods(cntlr, class_name):
     """Get method from Xule
-    
+
     Get a method/function from the Xule plugin. This is how this validator calls functions in the Xule plugin.
     """
-    return getXulePlugin(cntlr).get(class_name)
+    hooks = list(cntlr.plugins.hooks(class_name))
+    if not hooks:
+        cntlr.addToLog(
+            _("Plugin with '%(name)s' is not loaded. "
+              "Xule plugin is required to run %(rules)s rules. "
+              "This plugin should be automatically loaded."),
+            name=class_name,
+            rules='FERC',
+        )
+    return hooks
 
 def menuTools(cntlr, menu):
     """Add validator menu the Tools menu in the Arelle GUI
     
     This is invoked by the Arelle controller
     """
-    menu_method = getXuleMethod(cntlr, 'Xule.AddMenuTools')
-    version_method = getXuleMethod(cntlr, 'Xule.ValidatorVersion')
-    menu_method(cntlr, menu, _short_name, _version_prefix, __file__, _rule_set_map_name, _latest_map_name)
+    for menu_method in getXuleMethods(cntlr, 'Xule.AddMenuTools'):
+        menu_method(cntlr, menu, _short_name, _version_prefix, __file__, _rule_set_map_name, _latest_map_name)
 
 def validateMenuTools(cntlr, validateMenu, *args, **kwargs):
     """Add validator checkbutton to the Arelle Validate menu (under Tools).
     
     This is invoked by the Arelle controller.
     """
-    menu_method = getXuleMethod(cntlr, 'Xule.AddValidationMenuTools')
-    menu_method(cntlr, validateMenu, _short_name, _rule_set_map_name)
+    for menu_method in getXuleMethods(cntlr, 'Xule.AddValidationMenuTools'):
+        menu_method(cntlr, validateMenu, _short_name, _rule_set_map_name)
     
 __pluginInfo__ = {
     'name': _name,

--- a/plugin/xodel/__init__.py
+++ b/plugin/xodel/__init__.py
@@ -24,7 +24,6 @@ limitations under the License.
 $Change: $
 DOCSKIP
 """
-from arelle import PluginManager
 from .xodel import process_xodel
 
 import optparse

--- a/plugin/xule/__init__.py
+++ b/plugin/xule/__init__.py
@@ -58,7 +58,6 @@ except ImportError:
 
 from arelle import FileSource
 from arelle import ModelManager
-from arelle import PluginManager
 import optparse
 import os 
 import datetime


### PR DESCRIPTION
#### Description:
Refactor plugin invocation to align with the [upcoming deprecation](https://github.com/Arelle/Arelle/issues/2248) of the global `PluginManager` in Arelle. This update migrates logic to use the `PluginProvider` instance provided by the `Cntlr` (accessible via `cntlr.plugins`).

#### Questions:
I noticed the `Do not change anything below this line` comment, but I'm not familiar with the context around that. Perhaps this code is generated/copied from somewhere else?

@campbellpryde
@davidtauriello