### PR TITLE
Fix Application Crash From Enabling DQC plugin

### DIFF
--- a/plugin/xule/__init__.py
+++ b/plugin/xule/__init__.py
@@ -335,7 +335,7 @@ def addValidateMenuTools(cntlr, validateMenu, name, map_name):
         setattr(cntlr.modelManager, attr_name, validate_var.get())
         cntlr.config[attr_name] = getattr(cntlr.modelManager, attr_name)
         
-    validate_var.trace("w", setValidateXuleOption)
+    validate_var.trace_add("write", setValidateXuleOption)
     validateMenu.add_checkbutton(label=_("{} Rules".format(name)), 
                                  underline=0, 
                                  variable=validate_var, onvalue=True, offvalue=False)


### PR DESCRIPTION
Resolves [a bug report](https://github.com/Arelle/Arelle/issues/2553) where enabling the `DQC Rules Validator` plugin causes the Arelle GUI to crash on Windows when used with Python 3.14.7.

Newer Python releases have begun bundling Tcl/Tk 9 by default which removed the deprecated `trace` function. `trace_add` has been available since Python 3.6 and works with both Tcl/Tk 8.6 and 9.0.

We've made this same update [in base Arelle](https://github.com/Arelle/Arelle/pull/2274) and EDGAR is [including similar changes in 26.3](https://github.com/Arelle/EDGAR/pull/67).

@davidtauriello  @campbellpryde 