### PR TITLE
Performance: three algorithmic fixes in rule evaluation

### DIFF
--- a/plugin/xule/XuleContext.py
+++ b/plugin/xule/XuleContext.py
@@ -378,6 +378,10 @@ class XuleRuleContext(object):
         
         self.iteration_table = XuleIterationTable(self)
         self.vars = collections.defaultdict(list)
+        # node_ids whose variable stack currently has a 'for' variable on top. Maintained
+        # incrementally by add_var/add_arg/del_arg so find_for_vars() does not have to scan every
+        # variable on every call - it is called once per cache key, millions of times per filing.
+        self._for_var_nodes = set()
         self.id_prefix = []  
         self.column_prefix = []   
         self.no_alignment = False
@@ -524,6 +528,7 @@ class XuleRuleContext(object):
     def reset_iteration(self):
         """Reset the rule context for the next iteration of a rule"""
         self.vars = collections.defaultdict(list)
+        self._for_var_nodes = set()
         self.id_prefix = []
         self.column_prefix = []
         self.aligned_result_only = False
@@ -585,7 +590,8 @@ class XuleRuleContext(object):
                     }
 
         self.vars[node_id].append(var_info)
-                  
+        self._for_var_nodes.discard(node_id)
+
         return var_info
         
     def add_arg(self, name, node_id, tag, value, number, is_for=False):
@@ -614,18 +620,31 @@ class XuleRuleContext(object):
             var_info['is_for'] = True
 
         self.vars[node_id].append(var_info)
+        if is_for:
+            self._for_var_nodes.add(node_id)
+        else:
+            self._for_var_nodes.discard(node_id)
         if tag is not None:
             self.tags[tag] = value
     
     def del_arg(self, name, node_id):
         """Removes an argument from the variable stack"""
-        self.vars[node_id].pop()
-        if len(self.vars[node_id]) == 0:
+        var_stack = self.vars[node_id]
+        var_stack.pop()
+        if len(var_stack) == 0:
             del self.vars[node_id]
+            self._for_var_nodes.discard(node_id)
+        elif var_stack[-1].get('is_for', False):
+            self._for_var_nodes.add(node_id)
+        else:
+            self._for_var_nodes.discard(node_id)
 
     def find_for_vars(self):
-        # the [-1] is to get the last value for the variable on the stack.
-        return tuple(x[-1] for x in self.vars.values() if x[-1].get('is_for', False) == True)
+        # the [-1] is to get the last value for the variable on the stack. The caller collects these
+        # into a set, so the order is not significant.
+        if not self._for_var_nodes:
+            return ()
+        return tuple(self.vars[node_id][-1] for node_id in self._for_var_nodes)
 
     def find_var(self, var_name, node_id, constant_only=False):
         """Finds a variable in the variable stack

--- a/plugin/xule/XuleFunctions.py
+++ b/plugin/xule/XuleFunctions.py
@@ -355,12 +355,18 @@ def agg_list(xule_context, values):
 def agg_set(xule_context, values):
     set_values = []
     shadow = []
+    # Membership index for shadow. Checking "not in shadow" against the list is O(n) per value, so
+    # aggregating a large set degrades to O(n**2) full __eq__ comparisons. The shadow values are
+    # already required to be hashable - the frozenset(shadow) below depends on it - so a companion
+    # set answers the same question in O(1). shadow stays a list to preserve insertion order.
+    shadow_seen = set()
     tags = {}
     facts = collections.OrderedDict()
-    
+
     for current_value in values:
         if current_value.type in ('set', 'list', 'dictionary'):
-            if current_value.shadow_collection not in shadow:
+            if current_value.shadow_collection not in shadow_seen:
+                shadow_seen.add(current_value.shadow_collection)
                 set_values.append(current_value)
                 shadow.append(current_value.shadow_collection)
                 if current_value.tags is not None:
@@ -368,7 +374,8 @@ def agg_set(xule_context, values):
                 if current_value.facts is not None:
                     facts.update(current_value.facts)
         else:
-            if current_value.value not in shadow:
+            if current_value.value not in shadow_seen:
+                shadow_seen.add(current_value.value)
                 set_values.append(current_value)
                 shadow.append(current_value.value)
                 if current_value.tags is not None:

--- a/plugin/xule/XuleProcessor.py
+++ b/plugin/xule/XuleProcessor.py
@@ -4012,6 +4012,13 @@ def nav_finish_return_items(nav_expr, return_items, add_result_order, xule_conte
 
     final_results = list()
     final_shadow = list()
+    # Membership index for final_shadow. When the return type is a set, duplicates are dropped by
+    # checking the shadow value. Scanning final_shadow as a list makes that check O(n) per item
+    # (and each comparison is a full QName/tuple __eq__), so a large navigation degrades to O(n**2).
+    # The shadow values are already required to be hashable - the set return below builds a
+    # frozenset from them - so a companion set gives the same answer in O(1). final_shadow itself is
+    # still built as a list to preserve result ordering.
+    final_shadow_seen = set()
 
     def handle_return_item(return_item, cur_order):
 
@@ -4086,7 +4093,8 @@ def nav_finish_return_items(nav_expr, return_items, add_result_order, xule_conte
             final_results.append(item_result)
             final_shadow.append(item_shadow)
         else:  # Set
-            if item_shadow not in final_shadow:
+            if item_shadow not in final_shadow_seen:
+                final_shadow_seen.add(item_shadow)
                 final_results.append(item_result)
                 final_shadow.append(item_shadow)
 

--- a/plugin/xule/XuleValue.py
+++ b/plugin/xule/XuleValue.py
@@ -215,7 +215,13 @@ class XuleValue:
         self.aligned_result_only = False
         self.used_expressions = None
         self.shadow_collection = shadow_collection
-        self.tag = tag if tag is not None else self
+        # A value is its own tag unless an explicit tag was supplied. That default used to be stored
+        # as "self.tag = self", which put a reference cycle in every XuleValue: CPython can reclaim
+        # acyclic garbage the moment the refcount drops, but a self-reference can only be broken by
+        # the cyclic collector. With millions of XuleValues per filing that made the collector,
+        # rather than refcounting, responsible for nearly all of them. Storing None to mean "myself"
+        # and resolving it in the tag property keeps the behaviour and drops the cycle.
+        self._tag = tag
         self._hashable_system_value = None
         
         if self.type in ('list', 'set') and self.shadow_collection is None:
@@ -229,6 +235,15 @@ class XuleValue:
             self.shadow_collection = frozenset(shadow.items())
         elif self.type == 'string': # make all strings XuleStrings
             self.value = XuleString(self.value)
+    @property
+    def tag(self):
+        # None means "this value is its own tag" - see the note in __init__.
+        return self if self._tag is None else self._tag
+
+    @tag.setter
+    def tag(self, value):
+        self._tag = value
+
     @property
     def shadow_dictionary(self):
         if self.type == 'dictionary':


### PR DESCRIPTION
Three independent, behaviour-preserving fixes found by profiling DQC runs.
Each was measured separately; none changes rule semantics.

| filing | before | after | |
|---|---|---|---|
| data-resiliency-2020.xbrl (DQC 2025) | 88.3s | 54.3s | -38% |
| msft-20250630 10-K (DQC 2025) | 22.1s | 18.0s | -19% |
| Pacific Life N-CSR, 73.6k facts (DQC 2024) | 58.5s | 49.7s | -15% |

### 1. O(n^2) de-duplication (`nav_finish_return_items`, `agg_set`)

Both built sets by testing `value not in <list>` — a linear scan whose every
step is a full `QName`/tuple `__eq__`. Profiling data-resiliency showed
393M `QName.__eq__` calls, 358M from `nav_finish_return_items`, 31% of the
run from only 1625 calls of that function.

The shadow values are already required to be hashable (both functions end by
building a `frozenset` from them), so a companion set answers membership in
O(1). The ordering lists are untouched, so result order is unchanged.

data-resiliency 88.3s -> 69.0s. Gain is proportional to navigation result
size, so it is large for navigate-heavy rules and nil elsewhere.

### 2. Self-reference cycle in every `XuleValue`

`self.tag = tag if tag is not None else self` meant every value built without
an explicit tag referenced itself. CPython reclaims acyclic garbage on
refcount drop, but a self-cycle needs the collector — so all 3.8M values on a
large N-CSR waited for a GC pass. Measured GC pause time was 36% of the run.

Storing `None` for "I am my own tag" and resolving it in a property keeps
behaviour identical, including `clone()`, where a clone's tag still refers to
the original rather than to the clone.

N-CSR 56.7s -> 50.2s; GC pause time 20.6s -> 13.9s.

### 3. `find_for_vars()` rescanned every variable

Called once per cache key from `get_local_cache_key()` — 5.2M times on the
N-CSR, 5-7% of the run. Membership only changes on push/pop, so
`add_var`/`add_arg`/`del_arg` now maintain the set of node_ids whose stack
top is a for-variable. The single caller collects into a set, so iteration
order is not observable.

Cross-checked against the original scan on every call: 2,089,122 calls on
msft and 5,177,129 on the N-CSR, zero mismatches.

## Verification

Timings are minimum-of-N with interleaved A/B toggling (this machine varies
~7% run to run); every patched run beat every unpatched run. Rule output was
compared order-insensitively on all filings.

## Known issue this exposes

xule output is not reproducible run to run: `XuleValue.__eq__`/`__hash__` are
commented out, so values are identity-hashed and `frozenset` iteration
follows memory addresses. The unit suite already shows this on main (MIN105
flaps across runs). Because these changes alter allocation and object
lifetime, they reshuffle those addresses and widen the effect — main varies
110-111 mismatches over 5 runs, this branch 103-113, with the extra movement
in DO120-123, DO128, PFILT117/119/121/122/124 and UNITFILT006. All are rules
with multi-line, order-sensitive expected output.

This is pre-existing and orthogonal to the changes here, but it makes CI
results noisy. `--xule-ordered-iterations` does not address it — it sorts
`XuleValueSet` alignment keys only, not set-value iteration.