### PR TITLE
Make --xule-ordered-iterations produce reproducible output

### DIFF
--- a/plugin/xule/XuleProcessor.py
+++ b/plugin/xule/XuleProcessor.py
@@ -1686,7 +1686,7 @@ def evaluate_for(for_expr, xule_context):
         raise XuleProcessingError(_("For loop requires a set or list, found '{}'.".format(for_loop_collection.type)),
                                   xule_context)
 
-    for for_loop_var in for_loop_collection.value:
+    for for_loop_var in for_loop_collection.ordered_value:
         if for_loop_var.used_expressions is None:
             for_loop_var.used_expressions = used_expressions
         else:
@@ -2721,14 +2721,40 @@ def calc_fact_alignment(factset, fact, non_aligned_filters, align_aspects_filter
     return xule_context.fact_alignments[factset['node_id']][fact][0 if frozen else 1]
 
 
+def ordered_iteration(items, xule_context, key=None):
+    """Return items in a reproducible order when --xule-ordered-iterations is in effect.
+
+    Several collections in the processor are python sets whose members - ModelFacts, XuleValues,
+    ModelConcepts - are hashed by identity. Set iteration therefore follows memory addresses, which
+    differ between runs, so the order in which facts are bound and messages are produced is not
+    reproducible. PYTHONHASHSEED does not help, because identity hashes are not affected by it.
+
+    When the option is off this returns the collection untouched, so the default behaviour and cost
+    are unchanged.
+    """
+    if getattr(xule_context.global_context.options, 'xule_ordered_iterations', False):
+        try:
+            return sorted(items, key=key) if key is not None else sorted(items)
+        except TypeError:
+            # Not orderable - leave the collection alone rather than fail.
+            return items
+    return items
+
+
+def _fact_order_key(model_fact):
+    """Document load order. objectIndex is assigned as the model is built, so it is stable for a
+    given input document and cheap to sort on."""
+    return getattr(model_fact, 'objectIndex', 0)
+
+
 def process_filtered_facts(factset, pre_matched_facts, non_align_aspects, align_aspects,
-                           nested_filters, aspect_vars, pre_matched_used_expressions_ids, 
+                           nested_filters, aspect_vars, pre_matched_used_expressions_ids,
                            dimensions_special_value, dimensios_special_covered, xule_context):
     """Apply the where portion of the factset"""
     results = XuleValueSet()
     default_used_expressions = set()
 
-    for model_fact in pre_matched_facts:
+    for model_fact in ordered_iteration(pre_matched_facts, xule_context, _fact_order_key):
         # assume the fact will matach the where clause.
         matched = True
 
@@ -3112,7 +3138,7 @@ def evaluate_filter(filter_expr, xule_context):
         results = list()
         results_shadow = list()
 
-    for item_number, item_value in enumerate(collection_value.value):
+    for item_number, item_value in enumerate(collection_value.ordered_value):
         xule_context.add_arg('item',
                              filter_expr['expr']['node_id'],
                              None,
@@ -5316,7 +5342,7 @@ def result_message(rule_ast, result_ast, xule_value, xule_context):
         elif message_value.type in ('list','set'):
             # The rule focus is a list/set of concepts or facts. The list/set cannot be nested
             message = []
-            for rule_focus_item in message_value.value:
+            for rule_focus_item in message_value.ordered_value:
                 if rule_focus_item.type == 'concept':
                     message.append(rule_focus_item.value)
                 elif rule_focus_item.is_fact:

--- a/plugin/xule/XuleProperties.py
+++ b/plugin/xule/XuleProperties.py
@@ -337,7 +337,7 @@ def property_to_xince(xule_context, object_value, *args, _intermediate=False):
 def _prep_for_xince_json(xule_context, xule_value):
     if xule_value.type in ('set', 'list'):
         children_string = []
-        for item in xule_value.value:
+        for item in xule_value.ordered_value:
             children_string.append(property_to_xince(xule_context, item, _intermediate=True).value)
         return children_string
     if xule_value.type == 'dictionary':
@@ -356,7 +356,7 @@ def property_join(xule_context, object_value, *args):
         
         result_string = ''   
         next_sep = '' 
-        for item in object_value.value:
+        for item in object_value.ordered_value:
             result_string += next_sep + item.format_value()
             next_sep = sep.value
         
@@ -2375,7 +2375,7 @@ def property_denone(xule_context, object_value, *args):
     if object_value.type == 'set':
         new_value_content =frozenset({x for x in object_value.value if x.type != 'none'})
     else: # list
-        new_value_content = tuple(x for x in object_value.value if x.type != 'none')
+        new_value_content = tuple(x for x in object_value.ordered_value if x.type != 'none')
     
     new_value = xv.XuleValue(xule_context, new_value_content, object_value.type)
 

--- a/plugin/xule/XuleValue.py
+++ b/plugin/xule/XuleValue.py
@@ -135,18 +135,52 @@ class SortedValuesList(list):
         super().clear()
         self.is_sorted = False
 
+def xule_canonical_text(value):
+    """A canonical string for a value projected by sort_value.
+
+    sort_value returns comparable python data, but for a set it returns a python set and for a list
+    a python list, so str() of it is not stable - a nested set prints in its own hash order. Sorting
+    the members of any nested set makes the text depend only on content, giving a total order that
+    is the same in every run.
+    """
+    if isinstance(value, (set, frozenset)):
+        return '{' + ','.join(sorted(xule_canonical_text(item) for item in value)) + '}'
+    if isinstance(value, (list, tuple)):
+        return '[' + ','.join(xule_canonical_text(item) for item in value) + ']'
+    return str(value)
+
+
+def xule_value_order_key(xule_value):
+    """A total order over XuleValues, for reproducible iteration of a set."""
+    try:
+        return xule_canonical_text(xule_value.sort_value)
+    except Exception:
+        return xule_canonical_text(getattr(xule_value, 'value', ''))
+
+
+def _total_order_key(key):
+    """A canonical, totally ordered sort key.
+
+    The keys of a XuleValueSet are alignments: either None, or a frozenset of (aspect, member)
+    pairs. Sorting those with "key=lambda x: x" does not order them - comparison on a frozenset is
+    subset containment, which is only a *partial* order, so incomparable keys keep whatever order
+    they arrived in. Because that comparison also never raises, the str() fallback that used to
+    follow was unreachable. The incoming order comes from identity-hashed sets, so it varies from
+    run to run, which is why sorting here previously had no effect on reproducibility.
+
+    Building a canonical string gives a total order, so equal content always sorts the same way.
+    """
+    if key is None:
+        return ''  # the "no alignment" key sorts first
+    if isinstance(key, (frozenset, set)):
+        return '\x00'.join(sorted(str(item) for item in key))
+    return str(key)
+
+
 class SortedDefaultDict(collections.defaultdict):
     def __iter__(self):
-        try:
-            for k in sorted(super().keys(), key=lambda x: x):
-                yield k
-        except TypeError:
-            try:
-                for k in sorted(super().keys(), key=lambda x: str(x)):
-                    yield k
-            except TypeError:
-                for k in super().keys():
-                    yield k
+        for k in sorted(super().keys(), key=_total_order_key):
+            yield k
 
 class XuleValueSet:
     def __init__(self, values=None):
@@ -280,6 +314,34 @@ class XuleValue:
             return None      
         
         
+    @property
+    def ordered_value(self):
+        """The members of this value in a reproducible order.
+
+        Only sets are reordered. A xule set is stored as a frozenset of XuleValues, which are hashed
+        by identity, so its iteration order follows memory addresses and differs between runs. Lists
+        carry a meaningful order and every other type is returned untouched.
+
+        Ordering is applied only under --xule-ordered-iterations, so by default this costs one type
+        test. The sorted order is computed once and cached on the value.
+
+        Use this wherever the members of a collection are iterated to build output - a message, a
+        joined string, a serialized document. Set arithmetic must keep using .value, which stays a
+        frozenset so union/intersection/difference remain C speed.
+        """
+        if self.type != 'set':
+            return self.value
+        if not hasattr(self, '_ordered_value'):
+            options = XuleUtility.XuleVars.get(_CNTLR, 'options')
+            if options is not None and getattr(options, 'xule_ordered_iterations', False):
+                try:
+                    self._ordered_value = tuple(sorted(self.value, key=xule_value_order_key))
+                except TypeError:
+                    self._ordered_value = self.value
+            else:
+                self._ordered_value = self.value
+        return self._ordered_value
+
     @property
     def sort_value(self):
         if not hasattr(self, '_sort_value'):


### PR DESCRIPTION
`--xule-ordered-iterations` exists but does not currently make output
reproducible. This fixes that. Everything is behind the flag, which is off
by default, so default behaviour and cost are unchanged.

## Three causes

All three are iteration over a collection whose members are hashed by
identity, so the order followed memory addresses and differed between runs.
`PYTHONHASHSEED` does not affect identity hashes, so fixing the seed does not
help here.

1. **`SortedDefaultDict` never sorted anything.** It ordered `XuleValueSet`
   keys with `key=lambda x: x`. Those keys are alignments — `None`, or a
   frozenset of (aspect, member) pairs — and comparison on a frozenset is
   subset containment, which is only a *partial* order, so incomparable keys
   kept whatever order they arrived in. That comparison also never raises, so
   the `str()` fallback beneath it was unreachable. Replaced with a canonical
   string key.

2. **Fact binding order.** `process_filtered_facts` iterated
   `pre_matched_facts`, a set of `ModelFact`s, which decided the order facts
   were bound and therefore the order messages were produced. Now ordered by
   `objectIndex`, assigned in document load order.

3. **Sets iterated directly when building output.** Added
   `XuleValue.ordered_value`, which sorts a set once, caches it, and returns
   lists and every other type untouched. Applied at the six places where
   members are iterated to produce output: `for` loops, `filter`, a message's
   rule focus, `join`, `denone`, and json serialization.

## Why not an ordered set type

Set arithmetic deliberately still uses `.value`, which stays a `frozenset`.
`frozenset` union/intersection/difference are C implemented, while the ordered
set type in `arelle.PythonUtil` builds on `collections.abc.Set`, whose
operators are interpreted loops. Measured on 500 QNames:

| operation | frozenset | FrozenOrderedSet | |
|---|---|---|---|
| union | 6.1 µs | 59.7 µs | 9.8x |
| intersect | 3.3 µs | 49.4 µs | 15.1x |
| difference | 2.3 µs | 32.7 µs | 14.1x |
| iterate | 4.6 µs | 3.9 µs | 0.9x |

Iteration — the only thing we need ordered — is the only operation that does
not get worse. `property_sum` folds sets with `|` and profiles at ~4% of a
run, so changing the stored type would have cost far more than it bought.
Ordering iteration instead keeps it off the hot path.

## Verification

Three consecutive runs each, output byte identical where it previously
differed on every run:

| filing | before | with flag |
|---|---|---|
| data-resiliency-2020.xbrl | differed | identical |
| msft-20250630 (10-K) | differed | identical |
| Pacific Life N-CSR, 73.6k facts | differed | identical |

Cost with the flag on: +1.6% (msft 17.67s -> 17.96s, min of 3). With the flag
off, output matches the unmodified branch.

## Separate issue: CI reproducibility

The unit suite's run-to-run variation is **python hash randomisation**, a
different mechanism that this flag does not address. Over repeated runs of
`unitTests/source/base`:

seed unset, flag off      110, 110, 110, 111, 111   rule set moves
seed unset, flag on       111, 108, 112             rule set moves
PYTHONHASHSEED=0          107, 107, 107             stable
PYTHONHASHSEED=0 + flag   106, 106, 106             stable



Setting `PYTHONHASHSEED` in `.github/workflows/unittests.yml` would make the
suite reproducible on its own, on unmodified code. That is worth doing
independently of this PR — it is what makes CI runs comparable, and it
accounts for the variance noted in #49.